### PR TITLE
Add metrics of executed checks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab
 	github.com/openshift/client-go v0.0.0-20201020074620-f8fd44879f7c
 	github.com/openshift/library-go v0.0.0-20201109112824-093ad3cf6600
+	github.com/prometheus/client_golang v1.7.1
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1 // indirect

--- a/pkg/check/dummy.go
+++ b/pkg/check/dummy.go
@@ -1,14 +1,18 @@
 package check
 
 import (
-	"context"
 	"fmt"
 
-	"github.com/vmware/govmomi/vim25"
-	"k8s.io/legacy-cloud-providers/vsphere"
+	"github.com/vmware/govmomi/vim25/mo"
+	v1 "k8s.io/api/core/v1"
 )
 
-// CheckDummy is a dummy check that always fails to test the operator & its exp. backoff.
-func CheckDummy(ctx context.Context, vmConfig *vsphere.VSphereConfig, vmClient *vim25.Client, kubeClient KubeClient) error {
+// CheckClusterDummy is a dummy check that always fails to test the operator & its exp. backoff.
+func CheckClusterDummy(ctx *CheckContext) error {
+	return fmt.Errorf("Dummy error")
+}
+
+// CheckNodeDummy is a dummy check that always fails to test the operator & its exp. backoff.
+func CheckNodeDummy(ctx *CheckContext, node *v1.Node, vm *mo.VirtualMachine) error {
 	return fmt.Errorf("Dummy error")
 }

--- a/pkg/check/info.go
+++ b/pkg/check/info.go
@@ -1,0 +1,39 @@
+package check
+
+import (
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const (
+	versionLabel = "version"
+	vCenterUUID  = "uuid"
+)
+
+var (
+	vCenterInfoMetric = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Name:           "vsphere_vcenter_info",
+			Help:           "Information about vSphere vCenter.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{versionLabel, vCenterUUID},
+	)
+)
+
+func init() {
+	legacyregistry.MustRegister(vCenterInfoMetric)
+}
+
+// CollectClusterInfo grabs information about vSphere cluster and updates corresponding metrics.
+// It's not a vSphere check per se, just using the interface.
+func CollectClusterInfo(ctx *CheckContext) error {
+	collectVCenterInfo(ctx)
+	return nil
+}
+
+func collectVCenterInfo(ctx *CheckContext) {
+	version := ctx.VMClient.ServiceContent.About.Version
+	uuid := ctx.VMClient.ServiceContent.About.InstanceUuid
+	vCenterInfoMetric.WithLabelValues(version, uuid).Set(1.0)
+}

--- a/pkg/operator/metrics.go
+++ b/pkg/operator/metrics.go
@@ -1,0 +1,35 @@
+package operator
+
+import (
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const (
+	checkNameLabel = "check"
+)
+
+var (
+	clusterCheckMetric = metrics.NewHistogramVec(
+		&metrics.HistogramOpts{
+			Name:           "vsphere_cluster_check_duration_seconds",
+			Help:           "vSphere cluster-level check duration",
+			Buckets:        []float64{.1, .25, .5, 1, 2.5, 5, 10, 15, 30, 60, 120, 300, 600},
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{checkNameLabel},
+	)
+	clusterCheckErrrorMetric = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Name:           "vsphere_cluster_check_errors",
+			Help:           "Number of failed vSphere cluster-level checks performed by vsphere-problem-detector.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{checkNameLabel},
+	)
+)
+
+func init() {
+	legacyregistry.MustRegister(clusterCheckMetric)
+	legacyregistry.MustRegister(clusterCheckErrrorMetric)
+}

--- a/pkg/operator/metrics.go
+++ b/pkg/operator/metrics.go
@@ -7,7 +7,11 @@ import (
 
 const (
 	checkNameLabel = "check"
+	nodeNameLabel  = "node"
 )
+
+// This file contains operator metrics, especially status of each check.
+// For other metrics exposed by this operator, see pkg/check.
 
 var (
 	clusterCheckMetric = metrics.NewHistogramVec(
@@ -19,6 +23,7 @@ var (
 		},
 		[]string{checkNameLabel},
 	)
+
 	clusterCheckErrrorMetric = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Name:           "vsphere_cluster_check_errors",
@@ -27,9 +32,30 @@ var (
 		},
 		[]string{checkNameLabel},
 	)
+
+	nodeCheckMetric = metrics.NewHistogramVec(
+		&metrics.HistogramOpts{
+			Name:           "vsphere_node_check_duration_seconds",
+			Help:           "vSphere node-level check duration",
+			Buckets:        []float64{.1, .25, .5, 1, 2.5, 5, 10, 15, 30, 60, 120, 300, 600},
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{checkNameLabel, nodeNameLabel},
+	)
+
+	nodeCheckErrrorMetric = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Name:           "vsphere_node_check_errors",
+			Help:           "Number of failed vSphere node-level checks performed by vsphere-problem-detector.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{checkNameLabel, nodeNameLabel},
+	)
 )
 
 func init() {
 	legacyregistry.MustRegister(clusterCheckMetric)
 	legacyregistry.MustRegister(clusterCheckErrrorMetric)
+	legacyregistry.MustRegister(nodeCheckMetric)
+	legacyregistry.MustRegister(nodeCheckErrrorMetric)
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	"github.com/openshift/vsphere-problem-detector/pkg/check"
+	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	corelister "k8s.io/client-go/listers/core/v1"
@@ -28,7 +30,8 @@ type vSphereProblemDetectorController struct {
 	eventRecorder        events.Recorder
 
 	// List of checks to perform (useful for unit-tests: replace with a dummy check).
-	checks map[string]check.Check
+	clusterChecks map[string]check.ClusterCheck
+	nodeChecks    map[string]check.NodeCheck
 
 	lastCheck   time.Time
 	nextCheck   time.Time
@@ -75,7 +78,8 @@ func NewVSphereProblemDetectorController(
 		cloudConfigMapLister: cloudConfigMapInformer.Lister(),
 		infraLister:          configInformer.Lister(),
 		eventRecorder:        eventRecorder.WithComponentSuffix("vSphereProblemDetectorController"),
-		checks:               check.DefaultChecks,
+		clusterChecks:        check.DefaultClusterChecks,
+		nodeChecks:           check.DefaultNodeChecks,
 		backoff:              defaultBackoff,
 	}
 	return factory.New().WithSync(c.sync).WithSyncDegradedOnError(operatorClient).WithInformers(
@@ -133,17 +137,17 @@ func (c *vSphereProblemDetectorController) sync(ctx context.Context, syncCtx fac
 
 func resultConditionsFn(results []checkResult) v1helpers.UpdateStatusFunc {
 	return func(status *operatorv1.OperatorStatus) error {
-		for _, res := range results {
+		for i := range results {
 			st := operatorapi.ConditionTrue
 			reason := ""
-			if !res.Result {
+			if !results[i].Result {
 				st = operatorapi.ConditionFalse
 				reason = "CheckFailed"
 			}
 			cnd := operatorapi.OperatorCondition{
-				Type:    res.Name + "OK",
+				Type:    results[i].Name + "OK",
 				Status:  st,
-				Message: res.Message,
+				Message: results[i].Message,
 				Reason:  reason,
 			}
 			v1helpers.SetOperatorCondition(&status.Conditions, cnd)
@@ -159,32 +163,35 @@ func (c *vSphereProblemDetectorController) runChecks(ctx context.Context) (time.
 	}
 
 	var results []checkResult
-	failed := false
-	for name, checkFunc := range c.checks {
-		res := checkResult{
-			Name: name,
-		}
-		start := time.Now()
-		err := checkFunc(ctx, vmConfig, vmClient, c)
-		if err != nil {
-			res.Result = false
-			res.Message = err.Error()
-			failed = true
-			clusterCheckErrrorMetric.WithLabelValues(name).Inc()
-			klog.V(2).Infof("Check %q failed: %s", name, err)
-		} else {
-			res.Result = true
-			klog.V(42).Infof("Check %q passed", name)
-		}
-		duration := time.Now().Sub(start)
-		clusterCheckMetric.WithLabelValues(name).Observe(duration.Seconds())
-		results = append(results, res)
+	checkContext := &check.CheckContext{
+		Context:    ctx,
+		VMConfig:   vmConfig,
+		VMClient:   vmClient,
+		KubeClient: c,
 	}
 
+	var errs []error
+	clusterResults, err := c.runClusterChecks(checkContext)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	if clusterResults != nil {
+		results = append(results, clusterResults...)
+	}
+
+	nodeResults, err := c.runNodeChecks(checkContext)
+	if err != nil {
+		errs = append(errs, err)
+	}
+	if nodeResults != nil {
+		results = append(results, nodeResults...)
+	}
+
+	finalErr := errors.NewAggregate(errs)
 	c.lastResults = results
 	c.lastCheck = time.Now()
 	var nextDelay time.Duration
-	if failed {
+	if finalErr != nil {
 		nextDelay = c.backoff.Step()
 	} else {
 		// Reset the backoff on success
@@ -196,4 +203,89 @@ func (c *vSphereProblemDetectorController) runChecks(ctx context.Context) (time.
 	c.nextCheck = c.lastCheck.Add(nextDelay)
 	klog.V(4).Infof("Scheduled the next check in %s (%s)", nextDelay, c.nextCheck)
 	return nextDelay, nil
+}
+
+func (c *vSphereProblemDetectorController) runClusterChecks(checkContext *check.CheckContext) ([]checkResult, error) {
+	var errs []error
+	var results []checkResult
+	for name, checkFunc := range c.clusterChecks {
+		res := checkResult{
+			Name: name,
+		}
+		start := time.Now()
+		err := checkFunc(checkContext)
+		if err != nil {
+			res.Result = false
+			res.Message = err.Error()
+			errs = append(errs, err)
+			clusterCheckErrrorMetric.WithLabelValues(name).Inc()
+			klog.V(2).Infof("Check %q failed: %s", name, err)
+		} else {
+			res.Result = true
+			klog.V(4).Infof("Check %q passed", name)
+		}
+		duration := time.Now().Sub(start)
+		clusterCheckMetric.WithLabelValues(name).Observe(duration.Seconds())
+		results = append(results, res)
+	}
+
+	return results, errors.NewAggregate(errs)
+}
+
+func (c *vSphereProblemDetectorController) runNodeChecks(checkContext *check.CheckContext) ([]checkResult, error) {
+	nodes, err := c.ListNodes(checkContext.Context)
+	if err != nil {
+		return nil, err
+	}
+
+	// Prepare list of errors of each check
+	checkErrors := make(map[string][]error)
+	for name := range c.nodeChecks {
+		checkErrors[name] = []error{}
+	}
+
+	for i := range nodes {
+		node := &nodes[i]
+		vm, vmErr := c.getVM(checkContext, node)
+		// vmErr will be processed later to make all checks fail
+
+		for name, checkFunc := range c.nodeChecks {
+			start := time.Now()
+			var err error
+			if vmErr == nil {
+				err = checkFunc(checkContext, node, vm)
+			} else {
+				// Now use vmErr to mark all checks as failed with the same error
+				err = vmErr
+			}
+			if err != nil {
+				checkErrors[name] = append(checkErrors[name], fmt.Errorf("%s: %s", node.Name, err))
+				nodeCheckErrrorMetric.WithLabelValues(name, node.Name).Inc()
+				klog.V(2).Infof("Node %s: check %q failed: %s", node.Name, name, err)
+			} else {
+				klog.V(4).Infof("Node %s: check %q passed", node.Name, name)
+			}
+			duration := time.Now().Sub(start)
+			nodeCheckMetric.WithLabelValues(name, node.Name).Observe(duration.Seconds())
+		}
+	}
+
+	// Convert the errors to checkResults
+	var results []checkResult
+	var allErrors []error
+	for name := range c.nodeChecks {
+		errs := checkErrors[name]
+		res := checkResult{
+			Name: name,
+		}
+		if len(errs) != 0 {
+			res.Result = false
+			res.Message = errors.NewAggregate(errs).Error()
+			allErrors = append(allErrors, errs...)
+		} else {
+			res.Result = true
+		}
+		results = append(results, res)
+	}
+	return results, errors.NewAggregate(allErrors)
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -164,16 +164,20 @@ func (c *vSphereProblemDetectorController) runChecks(ctx context.Context) (time.
 		res := checkResult{
 			Name: name,
 		}
+		start := time.Now()
 		err := checkFunc(ctx, vmConfig, vmClient, c)
 		if err != nil {
 			res.Result = false
 			res.Message = err.Error()
 			failed = true
+			clusterCheckErrrorMetric.WithLabelValues(name).Inc()
 			klog.V(2).Infof("Check %q failed: %s", name, err)
 		} else {
 			res.Result = true
 			klog.V(42).Infof("Check %q passed", name)
 		}
+		duration := time.Now().Sub(start)
+		clusterCheckMetric.WithLabelValues(name).Observe(duration.Seconds())
 		results = append(results, res)
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -161,6 +161,7 @@ github.com/pkg/errors
 # github.com/pkg/profile v1.3.0
 github.com/pkg/profile
 # github.com/prometheus/client_golang v1.7.1
+## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp


### PR DESCRIPTION
Refactor the checks to have separate cluster-level ones and node-level ones - we want to track metrics for each node separately to be able to identify faulty nodes easily. In addition, several node checks will need VM object from vSphere, so let's load it only once.

For each cluster-level check, report duration (incl. total number of runs) + number of failed runs.
```
vsphere_cluster_check_duration_seconds_bucket{check="Dummy",le="0.1"} 4
vsphere_cluster_check_duration_seconds_bucket{check="Dummy",le="0.25"} 4
vsphere_cluster_check_duration_seconds_bucket{check="Dummy",le="0.5"} 4
vsphere_cluster_check_duration_seconds_bucket{check="Dummy",le="1"} 4
vsphere_cluster_check_duration_seconds_bucket{check="Dummy",le="2.5"} 4
vsphere_cluster_check_duration_seconds_bucket{check="Dummy",le="5"} 4
vsphere_cluster_check_duration_seconds_bucket{check="Dummy",le="10"} 4
vsphere_cluster_check_duration_seconds_bucket{check="Dummy",le="15"} 4
vsphere_cluster_check_duration_seconds_bucket{check="Dummy",le="30"} 4
vsphere_cluster_check_duration_seconds_bucket{check="Dummy",le="60"} 4
vsphere_cluster_check_duration_seconds_bucket{check="Dummy",le="120"} 4
vsphere_cluster_check_duration_seconds_bucket{check="Dummy",le="300"} 4
vsphere_cluster_check_duration_seconds_bucket{check="Dummy",le="600"} 4
vsphere_cluster_check_duration_seconds_bucket{check="Dummy",le="+Inf"} 4
vsphere_cluster_check_duration_seconds_sum{check="Dummy"} 0.00013443
vsphere_cluster_check_duration_seconds_count{check="Dummy"} 4
vsphere_cluster_check_errors{check="Dummy"} 4
```
(the dummy check always fails -> 4 runs, 4 failures, all of them very quick).

Report node checks separately for each node:
```
vsphere_node_check_errors{check="DummyNode",node="jsafrane-4ptps-master-0"} 2
vsphere_node_check_errors{check="DummyNode",node="jsafrane-4ptps-master-1"} 2
vsphere_node_check_errors{check="DummyNode",node="jsafrane-4ptps-master-2"} 2
vsphere_node_check_errors{check="DummyNode",node="jsafrane-4ptps-worker-6k89m"} 2
vsphere_node_check_errors{check="DummyNode",node="jsafrane-4ptps-worker-768js"} 2
vsphere_node_check_errors{check="DummyNode",node="jsafrane-4ptps-worker-zcnft"} 2
vsphere_node_check_duration_seconds_count{check="DummyNode",node="jsafrane-4ptps-worker-768js"} 2
vsphere_node_check_duration_seconds_bucket{check="DummyNode",node="jsafrane-4ptps-worker-zcnft",le="0.1"} 2
vsphere_node_check_duration_seconds_bucket{check="DummyNode",node="jsafrane-4ptps-worker-zcnft",le="0.25"} 2
vsphere_node_check_duration_seconds_bucket{check="DummyNode",node="jsafrane-4ptps-worker-zcnft",le="0.5"} 2
vsphere_node_check_duration_seconds_bucket{check="DummyNode",node="jsafrane-4ptps-worker-zcnft",le="1"} 2
vsphere_node_check_duration_seconds_bucket{check="DummyNode",node="jsafrane-4ptps-worker-zcnft",le="2.5"} 2
vsphere_node_check_duration_seconds_bucket{check="DummyNode",node="jsafrane-4ptps-worker-zcnft",le="5"} 2
vsphere_node_check_duration_seconds_bucket{check="DummyNode",node="jsafrane-4ptps-worker-zcnft",le="10"} 2
vsphere_node_check_duration_seconds_bucket{check="DummyNode",node="jsafrane-4ptps-worker-zcnft",le="15"} 2
vsphere_node_check_duration_seconds_bucket{check="DummyNode",node="jsafrane-4ptps-worker-zcnft",le="30"} 2
vsphere_node_check_duration_seconds_bucket{check="DummyNode",node="jsafrane-4ptps-worker-zcnft",le="60"} 2
vsphere_node_check_duration_seconds_bucket{check="DummyNode",node="jsafrane-4ptps-worker-zcnft",le="120"} 2
vsphere_node_check_duration_seconds_bucket{check="DummyNode",node="jsafrane-4ptps-worker-zcnft",le="300"} 2
vsphere_node_check_duration_seconds_bucket{check="DummyNode",node="jsafrane-4ptps-worker-zcnft",le="600"} 2
vsphere_node_check_duration_seconds_bucket{check="DummyNode",node="jsafrane-4ptps-worker-zcnft",le="+Inf"} 2
```
(omitting the other buckets with all runs, there's too many of them).

