### PR TITLE
Remove histogram from metrics

### DIFF
--- a/pkg/operator/metrics.go
+++ b/pkg/operator/metrics.go
@@ -14,11 +14,10 @@ const (
 // For other metrics exposed by this operator, see pkg/check.
 
 var (
-	clusterCheckMetric = metrics.NewHistogramVec(
-		&metrics.HistogramOpts{
-			Name:           "vsphere_cluster_check_duration_seconds",
-			Help:           "vSphere cluster-level check duration",
-			Buckets:        []float64{.1, .25, .5, 1, 2.5, 5, 10, 15, 30, 60, 120, 300, 600},
+	clusterCheckTotalMetric = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Name:           "vsphere_cluster_check_total",
+			Help:           "Number of vSphere cluster-level checks performed by vsphere-problem-detector, including both successes and failures.",
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{checkNameLabel},
@@ -33,11 +32,10 @@ var (
 		[]string{checkNameLabel},
 	)
 
-	nodeCheckMetric = metrics.NewHistogramVec(
-		&metrics.HistogramOpts{
-			Name:           "vsphere_node_check_duration_seconds",
-			Help:           "vSphere node-level check duration",
-			Buckets:        []float64{.1, .25, .5, 1, 2.5, 5, 10, 15, 30, 60, 120, 300, 600},
+	nodeCheckTotalMetric = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Name:           "vsphere_node_check_total",
+			Help:           "Number of vSphere node-level checks performed by vsphere-problem-detector, including both successes and failures.",
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{checkNameLabel, nodeNameLabel},
@@ -54,8 +52,8 @@ var (
 )
 
 func init() {
-	legacyregistry.MustRegister(clusterCheckMetric)
+	legacyregistry.MustRegister(clusterCheckTotalMetric)
 	legacyregistry.MustRegister(clusterCheckErrrorMetric)
-	legacyregistry.MustRegister(nodeCheckMetric)
+	legacyregistry.MustRegister(nodeCheckTotalMetric)
 	legacyregistry.MustRegister(nodeCheckErrrorMetric)
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -212,7 +212,6 @@ func (c *vSphereProblemDetectorController) runClusterChecks(checkContext *check.
 		res := checkResult{
 			Name: name,
 		}
-		start := time.Now()
 		err := checkFunc(checkContext)
 		if err != nil {
 			res.Result = false
@@ -224,8 +223,7 @@ func (c *vSphereProblemDetectorController) runClusterChecks(checkContext *check.
 			res.Result = true
 			klog.V(4).Infof("Check %q passed", name)
 		}
-		duration := time.Now().Sub(start)
-		clusterCheckMetric.WithLabelValues(name).Observe(duration.Seconds())
+		clusterCheckTotalMetric.WithLabelValues(name).Inc()
 		results = append(results, res)
 	}
 
@@ -250,7 +248,6 @@ func (c *vSphereProblemDetectorController) runNodeChecks(checkContext *check.Che
 		// vmErr will be processed later to make all checks fail
 
 		for name, checkFunc := range c.nodeChecks {
-			start := time.Now()
 			var err error
 			if vmErr == nil {
 				err = checkFunc(checkContext, node, vm)
@@ -265,8 +262,7 @@ func (c *vSphereProblemDetectorController) runNodeChecks(checkContext *check.Che
 			} else {
 				klog.V(4).Infof("Node %s: check %q passed", node.Name, name)
 			}
-			duration := time.Now().Sub(start)
-			nodeCheckMetric.WithLabelValues(name, node.Name).Observe(duration.Seconds())
+			nodeCheckTotalMetric.WithLabelValues(name, node.Name).Inc()
 		}
 	}
 


### PR DESCRIPTION
Report only these counters:

```
vsphere_cluster_check_total
vsphere_cluster_check_errors
vsphere_node_check_total
vsphere_node_check_errors
```

Full histogram per check per node could be too heavy for Prometheus database.