### PR TITLE
Don't set Degraded when on other clouds

### DIFF
--- a/pkg/operator/vmware.go
+++ b/pkg/operator/vmware.go
@@ -96,6 +96,9 @@ func (c *vSphereProblemDetectorController) getVSphereConfig(ctx context.Context)
 	if err != nil {
 		return "", err
 	}
+	if infra.Status.PlatformStatus == nil {
+		return "", fmt.Errorf("unknown platform: infrastructure status.platformStatus is nil")
+	}
 	if infra.Status.PlatformStatus.Type != ocpv1.VSpherePlatformType {
 		return "", fmt.Errorf("unsupported platform: %s", infra.Status.PlatformStatus.Type)
 	}


### PR DESCRIPTION
The operator should set Available: true and not to do anything when running on a non-vsphere cloud.

Reworked detection of the first `sync()` call a bit, it should be more obvious now.