### PR TITLE
Add metrics with node HW version and ESXi host version

### DIFF
--- a/pkg/check/interface.go
+++ b/pkg/check/interface.go
@@ -29,11 +29,12 @@ var (
 	DefaultNodeChecks []NodeCheck = []NodeCheck{
 		&CheckNodeDiskUUID{},
 		&CheckNodeProviderID{},
+		&CollectNodeHWVersion{},
 	}
 
 	// NodeProperties is a list of properties that NodeCheck can rely on to be pre-filled.
 	// Add a property to this list when a NodeCheck uses it.
-	NodeProperties = []string{"config.extraConfig", "config.flags"}
+	NodeProperties = []string{"config.extraConfig", "config.flags", "config.version"}
 )
 
 // KubeClient is an interface between individual vSphere check and Kubernetes.

--- a/pkg/check/interface.go
+++ b/pkg/check/interface.go
@@ -30,11 +30,12 @@ var (
 		&CheckNodeDiskUUID{},
 		&CheckNodeProviderID{},
 		&CollectNodeHWVersion{},
+		&CollectNodeESXiVersion{},
 	}
 
 	// NodeProperties is a list of properties that NodeCheck can rely on to be pre-filled.
 	// Add a property to this list when a NodeCheck uses it.
-	NodeProperties = []string{"config.extraConfig", "config.flags", "config.version"}
+	NodeProperties = []string{"config.extraConfig", "config.flags", "config.version", "runtime.host"}
 )
 
 // KubeClient is an interface between individual vSphere check and Kubernetes.

--- a/pkg/check/node_esxi_version.go
+++ b/pkg/check/node_esxi_version.go
@@ -1,0 +1,92 @@
+package check
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/klog/v2"
+)
+
+// CollectNodeESXiVersion emits metric with version of each ESXi host that runs at least a single VM with node.
+type CollectNodeESXiVersion struct {
+	// map ESXI host name ("host-12345", not hostname nor IP address!) -> version
+	esxiVersions map[string]string
+}
+
+var _ NodeCheck = &CollectNodeESXiVersion{}
+
+var (
+	esxiVersionMetric = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Name:           "vsphere_esxi_version_total",
+			Help:           "Number of ESXi hosts with given version.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{versionLabel},
+	)
+)
+
+func init() {
+	legacyregistry.MustRegister(esxiVersionMetric)
+}
+
+func (c *CollectNodeESXiVersion) Name() string {
+	return "CollectNodeESXiVersion"
+}
+
+func (c *CollectNodeESXiVersion) StartCheck() error {
+	c.esxiVersions = make(map[string]string)
+	return nil
+}
+
+func (c *CollectNodeESXiVersion) CheckNode(ctx *CheckContext, node *v1.Node, vm *mo.VirtualMachine) error {
+	hostRef := vm.Runtime.Host
+	if hostRef == nil {
+		return fmt.Errorf("error getting ESXi host for node %s: vm.runtime.host is empty", node.Name)
+	}
+	hostName := hostRef.Value
+	if ver, found := c.esxiVersions[hostName]; found {
+		klog.V(4).Infof("Node %s runs on cached ESXi host %s: %s", node.Name, hostName, ver)
+		return nil
+	}
+
+	// Load the HostSystem properties
+	host := object.NewHostSystem(ctx.VMClient, *hostRef)
+	tctx, cancel := context.WithTimeout(ctx.Context, *Timeout)
+	defer cancel()
+	var o mo.HostSystem
+
+	err := host.Properties(tctx, host.Reference(), []string{"name", "config.product.version"}, &o)
+	if err != nil {
+		return fmt.Errorf("failed to load ESXi host %s for node %s: %s", hostName, node.Name, err)
+	}
+
+	if o.Config == nil {
+		return fmt.Errorf("error getting ESXi host version for node %s: host.config is nil", node.Name)
+	}
+	version := o.Config.Product.Version
+	realHostName := o.Name // "10.0.0.2" or other user-friendly name of the host.
+	klog.V(2).Infof("Node %s runs on host %s (%s) with ESXi version: %s", node.Name, hostName, realHostName, version)
+	c.esxiVersions[hostName] = version
+
+	return nil
+}
+
+func (c *CollectNodeESXiVersion) FinishCheck() {
+	// Count the versions
+	versions := make(map[string]int)
+	for _, version := range c.esxiVersions {
+		versions[version]++
+	}
+
+	// Report the count
+	for version, count := range versions {
+		esxiVersionMetric.WithLabelValues(version).Set(float64(count))
+	}
+	return
+}

--- a/pkg/check/node_hw_version.go
+++ b/pkg/check/node_hw_version.go
@@ -1,0 +1,59 @@
+package check
+
+import (
+	"github.com/vmware/govmomi/vim25/mo"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+	"k8s.io/klog/v2"
+)
+
+// CollectNodeHWVersion emits metric with HW version of each VM
+type CollectNodeHWVersion struct {
+	// map HW version -> count of nodes with this version
+	hwVersions map[string]int
+}
+
+var _ NodeCheck = &CollectNodeHWVersion{}
+
+const (
+	hwVersionLabel = "hw_version"
+)
+
+var (
+	hwVersionMetric = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Name:           "vsphere_node_hw_version_total",
+			Help:           "Number of vSphere nodes with given HW version.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{hwVersionLabel},
+	)
+)
+
+func init() {
+	legacyregistry.MustRegister(hwVersionMetric)
+}
+
+func (c *CollectNodeHWVersion) Name() string {
+	return "CollectNodeHWVersion"
+}
+
+func (c *CollectNodeHWVersion) StartCheck() error {
+	c.hwVersions = make(map[string]int)
+	return nil
+}
+
+func (c *CollectNodeHWVersion) CheckNode(ctx *CheckContext, node *v1.Node, vm *mo.VirtualMachine) error {
+	hwVersion := vm.Config.Version
+	klog.V(2).Infof("Node %s has HW version %s", node.Name, hwVersion)
+	c.hwVersions[hwVersion]++
+	return nil
+}
+
+func (c *CollectNodeHWVersion) FinishCheck() {
+	for hwVersion, count := range c.hwVersions {
+		hwVersionMetric.WithLabelValues(hwVersion).Set(float64(count))
+	}
+	return
+}

--- a/pkg/check/node_provider.go
+++ b/pkg/check/node_provider.go
@@ -9,11 +9,26 @@ import (
 )
 
 // CheckNodeProviderID makes sure that all nodes have ProviderID set.
-func CheckNodeProviderID(ctx *CheckContext, node *v1.Node, vm *mo.VirtualMachine) error {
+type CheckNodeProviderID struct{}
+
+var _ NodeCheck = &CheckNodeProviderID{}
+
+func (c *CheckNodeProviderID) Name() string {
+	return "CheckNodeDiskUUID"
+}
+
+func (c *CheckNodeProviderID) StartCheck() error {
+	return nil
+}
+
+func (c *CheckNodeProviderID) CheckNode(ctx *CheckContext, node *v1.Node, vm *mo.VirtualMachine) error {
 	if node.Spec.ProviderID == "" {
 		return fmt.Errorf("the node has no node.spec.providerID configured")
 	}
 	klog.V(4).Infof("... the node has providerID: %s", node.Spec.ProviderID)
-
 	return nil
+}
+
+func (c *CheckNodeProviderID) FinishCheck() {
+	return
 }

--- a/pkg/check/node_uuid.go
+++ b/pkg/check/node_uuid.go
@@ -9,7 +9,19 @@ import (
 )
 
 // CheckNodeDiskUUID makes sure that all nodes have disk.enableUUID=TRUE.
-func CheckNodeDiskUUID(ctx *CheckContext, node *v1.Node, vm *mo.VirtualMachine) error {
+type CheckNodeDiskUUID struct{}
+
+var _ NodeCheck = &CheckNodeDiskUUID{}
+
+func (c *CheckNodeDiskUUID) Name() string {
+	return "CheckNodeDiskUUID"
+}
+
+func (c *CheckNodeDiskUUID) StartCheck() error {
+	return nil
+}
+
+func (c *CheckNodeDiskUUID) CheckNode(ctx *CheckContext, node *v1.Node, vm *mo.VirtualMachine) error {
 	if vm.Config.Flags.DiskUuidEnabled == nil {
 		return fmt.Errorf("the node has empty disk.enableUUID")
 	}
@@ -18,4 +30,8 @@ func CheckNodeDiskUUID(ctx *CheckContext, node *v1.Node, vm *mo.VirtualMachine) 
 	}
 	klog.V(4).Infof("... the node has correct disk.enableUUID")
 	return nil
+}
+
+func (c *CheckNodeDiskUUID) FinishCheck() {
+	return
 }


### PR DESCRIPTION
```
vsphere_esxi_version_total{version="7.0.0"} 3
vsphere_node_hw_version_total{hw_version="vmx-13"} 6
```

* Using HW version as reported by vSphere, i.e. "vmx-N".
* Reworked node check interface:  `NodeCheck` is now an interface that can collect some information / cache  during check of each node to be able to report cumulative metrics of nodes.
  * As advantage, all node metrics will be separate functions, for easier readability.
  * Will be reused to collect other node-specific metrics, like ESXi host versions.

@openshift/storage 
