### PR TITLE
Remove node and cluster check metrics that are always returned

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/vsphere-problem-detector
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/pkg/operator/metrics.go
+++ b/pkg/operator/metrics.go
@@ -14,15 +14,6 @@ const (
 // For other metrics exposed by this operator, see pkg/check.
 
 var (
-	clusterCheckTotalMetric = metrics.NewCounterVec(
-		&metrics.CounterOpts{
-			Name:           "vsphere_cluster_check_total",
-			Help:           "Number of vSphere cluster-level checks performed by vsphere-problem-detector, including both successes and failures.",
-			StabilityLevel: metrics.ALPHA,
-		},
-		[]string{checkNameLabel},
-	)
-
 	clusterCheckErrrorMetric = metrics.NewCounterVec(
 		&metrics.CounterOpts{
 			Name:           "vsphere_cluster_check_errors",
@@ -30,15 +21,6 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{checkNameLabel},
-	)
-
-	nodeCheckTotalMetric = metrics.NewCounterVec(
-		&metrics.CounterOpts{
-			Name:           "vsphere_node_check_total",
-			Help:           "Number of vSphere node-level checks performed by vsphere-problem-detector, including both successes and failures.",
-			StabilityLevel: metrics.ALPHA,
-		},
-		[]string{checkNameLabel, nodeNameLabel},
 	)
 
 	nodeCheckErrrorMetric = metrics.NewCounterVec(
@@ -52,8 +34,6 @@ var (
 )
 
 func init() {
-	legacyregistry.MustRegister(clusterCheckTotalMetric)
 	legacyregistry.MustRegister(clusterCheckErrrorMetric)
-	legacyregistry.MustRegister(nodeCheckTotalMetric)
 	legacyregistry.MustRegister(nodeCheckErrrorMetric)
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -206,7 +206,6 @@ func (c *vSphereProblemDetectorController) runClusterChecks(checkContext *check.
 			res.Result = true
 			klog.V(2).Infof("%s passed", name)
 		}
-		clusterCheckTotalMetric.WithLabelValues(name).Inc()
 		results = append(results, res)
 	}
 
@@ -246,7 +245,6 @@ func (c *vSphereProblemDetectorController) runNodeChecks(checkContext *check.Che
 			} else {
 				klog.V(2).Infof("%s:%s passed", name, node.Name)
 			}
-			nodeCheckTotalMetric.WithLabelValues(name, node.Name).Inc()
 		}
 	}
 


### PR DESCRIPTION
The `_check` metrics that reported in case of success are not necessary.

