### PR TITLE
Bug 1904502: Parallelize all checks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/openshift/build-machinery-go v0.0.0-20200917070002-f171684f77ab
 	github.com/openshift/client-go v0.0.0-20201020074620-f8fd44879f7c
 	github.com/openshift/library-go v0.0.0-20201109112824-093ad3cf6600
-	github.com/prometheus/client_golang v1.7.1
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1 // indirect
@@ -27,6 +26,7 @@ require (
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
+	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	golang.org/x/sys v0.0.0-20201112073958-5cba982894dd // indirect
 	golang.org/x/text v0.3.4 // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect

--- a/pkg/operator/pool.go
+++ b/pkg/operator/pool.go
@@ -1,0 +1,129 @@
+package operator
+
+import (
+	"context"
+	"sync"
+
+	"github.com/openshift/vsphere-problem-detector/pkg/check"
+	"golang.org/x/sync/semaphore"
+	"k8s.io/klog/v2"
+)
+
+// CheckThreadPool runs individual functions (presumably checks) as go routines.
+// It makes sure that only limited number of functions actually run in parallel.
+type CheckThreadPool struct {
+	wg  sync.WaitGroup
+	sem *semaphore.Weighted
+}
+
+// Creates a new CheckThreadPool with given max. number of goroutines.
+func NewCheckThreadPool(parallelism int64) *CheckThreadPool {
+	return &CheckThreadPool{
+		sem: semaphore.NewWeighted(parallelism),
+	}
+}
+
+// RunGoroutine spawns a new go routine with given check.
+// The goroutine waits for a semaphore, so only limited number
+// of goroutines actually run in parallel.
+// If the check cannot start before ctx finishes, the check
+// is not performed at all and it is silently thrown away,
+// assuming the operator is shutting down anyway.
+func (r *CheckThreadPool) RunGoroutine(ctx context.Context, check func()) {
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+
+		err := r.sem.Acquire(ctx, 1)
+		if err != nil {
+			// This means the operator is being stopped
+			klog.V(2).Infof("Warning: check stopped, operator is shutting down: %s", err)
+			return
+		}
+		defer r.sem.Release(1)
+		check()
+	}()
+}
+
+// Wait blocks until all previously started goroutines finish
+// or ctx expires.
+func (r *CheckThreadPool) Wait(ctx context.Context) error {
+	done := make(chan interface{})
+	go func() {
+		r.wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-done:
+		return nil
+	}
+}
+
+// ResultCollector accumulates results of each check,
+// as the checks run in parallel.
+type ResultCollector struct {
+	resultsMutex sync.Mutex
+	results      map[string][]error
+}
+
+// NewResultCollector creates a new ResultCollector
+func NewResultsCollector() *ResultCollector {
+	return &ResultCollector{
+		results: make(map[string][]error),
+	}
+}
+
+// AddResult stores result of a single check.
+// It is allowed to store result of a single check
+// several times, e.g. once for each node.
+// The collector will merge the result.
+func (r *ResultCollector) AddResult(res checkResult) {
+	name := res.Name
+
+	r.resultsMutex.Lock()
+	defer r.resultsMutex.Unlock()
+
+	oldRes, found := r.results[name]
+	if !found {
+		r.results[name] = []error{res.Error}
+		return
+	}
+
+	r.results[name] = append(oldRes, res.Error)
+}
+
+// Collect returns currently accumulated checks.
+// It merges results of the same check into a single error
+// It returns status of each check and overall status
+// of all checks.
+func (r *ResultCollector) Collect() ([]checkResult, []error) {
+	r.resultsMutex.Lock()
+	defer r.resultsMutex.Unlock()
+
+	var allErrs []error
+	var checkResults []checkResult
+	for name, checkErrors := range r.results {
+		res := checkResult{
+			Name: name,
+		}
+		var errs []error
+		// Filter out all nil errors
+		for _, err := range checkErrors {
+			if err == nil {
+				continue
+			}
+			errs = append(errs, err)
+			allErrs = append(allErrs, err)
+		}
+		if len(errs) == 0 {
+			res.Error = nil
+		} else {
+			res.Error = check.JoinErrors(errs)
+		}
+		checkResults = append(checkResults, res)
+	}
+	return checkResults, allErrs
+}

--- a/pkg/operator/pool.go
+++ b/pkg/operator/pool.go
@@ -66,7 +66,10 @@ func (r *CheckThreadPool) Wait(ctx context.Context) error {
 // as the checks run in parallel.
 type ResultCollector struct {
 	resultsMutex sync.Mutex
-	results      map[string][]error
+	// map check name -> list of all check results incl. all nil errors.
+	// For cluster level checks, only one error is expected, for node
+	// level checks, every node will have a single error here.
+	results map[string][]error
 }
 
 // NewResultCollector creates a new ResultCollector

--- a/pkg/operator/pool.go
+++ b/pkg/operator/pool.go
@@ -100,9 +100,10 @@ func (r *ResultCollector) AddResult(res checkResult) {
 
 // Collect returns currently accumulated checks.
 // It merges results of the same check into a single error
-// It returns status of each check and overall status
-// of all checks.
-func (r *ResultCollector) Collect() ([]checkResult, []error) {
+// It returns status of each check and overall
+// succeeded / failed status of all checks.
+func (r *ResultCollector) Collect() ([]checkResult, bool) {
+	failed := false
 	r.resultsMutex.Lock()
 	defer r.resultsMutex.Unlock()
 
@@ -125,8 +126,8 @@ func (r *ResultCollector) Collect() ([]checkResult, []error) {
 			res.Error = nil
 		} else {
 			res.Error = check.JoinErrors(errs)
+			failed = true
 		}
-		checkResults = append(checkResults, res)
 	}
-	return checkResults, allErrs
+	return checkResults, failed
 }

--- a/vendor/golang.org/x/sync/semaphore/semaphore.go
+++ b/vendor/golang.org/x/sync/semaphore/semaphore.go
@@ -1,0 +1,136 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package semaphore provides a weighted semaphore implementation.
+package semaphore // import "golang.org/x/sync/semaphore"
+
+import (
+	"container/list"
+	"context"
+	"sync"
+)
+
+type waiter struct {
+	n     int64
+	ready chan<- struct{} // Closed when semaphore acquired.
+}
+
+// NewWeighted creates a new weighted semaphore with the given
+// maximum combined weight for concurrent access.
+func NewWeighted(n int64) *Weighted {
+	w := &Weighted{size: n}
+	return w
+}
+
+// Weighted provides a way to bound concurrent access to a resource.
+// The callers can request access with a given weight.
+type Weighted struct {
+	size    int64
+	cur     int64
+	mu      sync.Mutex
+	waiters list.List
+}
+
+// Acquire acquires the semaphore with a weight of n, blocking until resources
+// are available or ctx is done. On success, returns nil. On failure, returns
+// ctx.Err() and leaves the semaphore unchanged.
+//
+// If ctx is already done, Acquire may still succeed without blocking.
+func (s *Weighted) Acquire(ctx context.Context, n int64) error {
+	s.mu.Lock()
+	if s.size-s.cur >= n && s.waiters.Len() == 0 {
+		s.cur += n
+		s.mu.Unlock()
+		return nil
+	}
+
+	if n > s.size {
+		// Don't make other Acquire calls block on one that's doomed to fail.
+		s.mu.Unlock()
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	ready := make(chan struct{})
+	w := waiter{n: n, ready: ready}
+	elem := s.waiters.PushBack(w)
+	s.mu.Unlock()
+
+	select {
+	case <-ctx.Done():
+		err := ctx.Err()
+		s.mu.Lock()
+		select {
+		case <-ready:
+			// Acquired the semaphore after we were canceled.  Rather than trying to
+			// fix up the queue, just pretend we didn't notice the cancelation.
+			err = nil
+		default:
+			isFront := s.waiters.Front() == elem
+			s.waiters.Remove(elem)
+			// If we're at the front and there're extra tokens left, notify other waiters.
+			if isFront && s.size > s.cur {
+				s.notifyWaiters()
+			}
+		}
+		s.mu.Unlock()
+		return err
+
+	case <-ready:
+		return nil
+	}
+}
+
+// TryAcquire acquires the semaphore with a weight of n without blocking.
+// On success, returns true. On failure, returns false and leaves the semaphore unchanged.
+func (s *Weighted) TryAcquire(n int64) bool {
+	s.mu.Lock()
+	success := s.size-s.cur >= n && s.waiters.Len() == 0
+	if success {
+		s.cur += n
+	}
+	s.mu.Unlock()
+	return success
+}
+
+// Release releases the semaphore with a weight of n.
+func (s *Weighted) Release(n int64) {
+	s.mu.Lock()
+	s.cur -= n
+	if s.cur < 0 {
+		s.mu.Unlock()
+		panic("semaphore: released more than held")
+	}
+	s.notifyWaiters()
+	s.mu.Unlock()
+}
+
+func (s *Weighted) notifyWaiters() {
+	for {
+		next := s.waiters.Front()
+		if next == nil {
+			break // No more waiters blocked.
+		}
+
+		w := next.Value.(waiter)
+		if s.size-s.cur < w.n {
+			// Not enough tokens for the next waiter.  We could keep going (to try to
+			// find a waiter with a smaller request), but under load that could cause
+			// starvation for large requests; instead, we leave all remaining waiters
+			// blocked.
+			//
+			// Consider a semaphore used as a read-write lock, with N tokens, N
+			// readers, and one writer.  Each reader can Acquire(1) to obtain a read
+			// lock.  The writer can Acquire(N) to obtain a write lock, excluding all
+			// of the readers.  If we allow the readers to jump ahead in the queue,
+			// the writer will starve — there is always one token available for every
+			// reader.
+			break
+		}
+
+		s.cur += w.n
+		s.waiters.Remove(next)
+		close(w.ready)
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -161,7 +161,6 @@ github.com/pkg/errors
 # github.com/pkg/profile v1.3.0
 github.com/pkg/profile
 # github.com/prometheus/client_golang v1.7.1
-## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
@@ -282,6 +281,8 @@ golang.org/x/net/websocket
 golang.org/x/oauth2
 golang.org/x/oauth2/internal
 # golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
+## explicit
+golang.org/x/sync/semaphore
 golang.org/x/sync/singleflight
 # golang.org/x/sys v0.0.0-20201112073958-5cba982894dd
 ## explicit


### PR DESCRIPTION
The operator should run all checks in parallel. At the same time, the number of goroutines should be limited, not to spam vSphere / Kubernetes API too much.

* Introducing `CheckThreadPool`, that spawns a goroutine for each check, however, makes sure that only few of them can run in parallel. The rest of them wait for a semaphore.

* Since everything runs in parallel, introducing `ResultCollector` that collects results of each check. When a check is run multiple times (e.g. separately for each node), it collects all its errors.

WIP:
* unit tests (as separate PR)
* ~update the node checks to run in parallel - they will need a lock when accessing their caches.~