### PR TITLE
Bug 1915859: Fix reporting of node metrics

### DIFF
--- a/pkg/check/interface.go
+++ b/pkg/check/interface.go
@@ -78,6 +78,8 @@ type NodeCheck interface {
 	// Multiple CheckNodes can run in parallel, each for a different node!
 	CheckNode(ctx *CheckContext, node *v1.Node, vm *mo.VirtualMachine) error
 	// Finish current round of checks. The check may report metrics here.
+	// Since it's called serially for all checks, it should not perform too
+	// expensive calculations. In addition, it must respect ctx.Context.
 	// It will be called after all CheckNode calls finish.
-	FinishCheck()
+	FinishCheck(ctx *CheckContext)
 }

--- a/pkg/check/node_esxi_version.go
+++ b/pkg/check/node_esxi_version.go
@@ -80,7 +80,7 @@ func (c *CollectNodeESXiVersion) CheckNode(ctx *CheckContext, node *v1.Node, vm 
 	return nil
 }
 
-func (c *CollectNodeESXiVersion) FinishCheck() {
+func (c *CollectNodeESXiVersion) FinishCheck(ctx *CheckContext) {
 	// Count the versions
 	versions := make(map[string]int)
 	for _, version := range c.esxiVersions {

--- a/pkg/check/node_hw_version.go
+++ b/pkg/check/node_hw_version.go
@@ -60,7 +60,7 @@ func (c *CollectNodeHWVersion) CheckNode(ctx *CheckContext, node *v1.Node, vm *m
 	return nil
 }
 
-func (c *CollectNodeHWVersion) FinishCheck() {
+func (c *CollectNodeHWVersion) FinishCheck(ctx *CheckContext) {
 	c.hwVersionsLock.Lock()
 	defer c.hwVersionsLock.Unlock()
 

--- a/pkg/check/node_provider.go
+++ b/pkg/check/node_provider.go
@@ -29,6 +29,6 @@ func (c *CheckNodeProviderID) CheckNode(ctx *CheckContext, node *v1.Node, vm *mo
 	return nil
 }
 
-func (c *CheckNodeProviderID) FinishCheck() {
+func (c *CheckNodeProviderID) FinishCheck(ctx *CheckContext) {
 	return
 }

--- a/pkg/check/node_uuid.go
+++ b/pkg/check/node_uuid.go
@@ -32,6 +32,6 @@ func (c *CheckNodeDiskUUID) CheckNode(ctx *CheckContext, node *v1.Node, vm *mo.V
 	return nil
 }
 
-func (c *CheckNodeDiskUUID) FinishCheck() {
+func (c *CheckNodeDiskUUID) FinishCheck(ctx *CheckContext) {
 	return
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -162,7 +162,7 @@ func (c *vSphereProblemDetectorController) runChecks(ctx context.Context) (time.
 	if err := checkRunner.Wait(ctx); err != nil {
 		return 0, err
 	}
-	c.finishNodeChecks()
+	c.finishNodeChecks(checkContext)
 
 	klog.V(4).Infof("All checks complete")
 
@@ -275,10 +275,10 @@ func (c *vSphereProblemDetectorController) runSingleNodeSingleCheck(checkContext
 	resultCollector.AddResult(res)
 }
 
-func (c *vSphereProblemDetectorController) finishNodeChecks() {
+func (c *vSphereProblemDetectorController) finishNodeChecks(ctx *check.CheckContext) {
 	for i := range c.nodeChecks {
 		check := c.nodeChecks[i]
-		check.FinishCheck()
+		check.FinishCheck(ctx)
 	}
 }
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -162,6 +162,7 @@ func (c *vSphereProblemDetectorController) runChecks(ctx context.Context) (time.
 	if err := checkRunner.Wait(ctx); err != nil {
 		return 0, err
 	}
+	c.finishNodeChecks()
 
 	klog.V(4).Infof("All checks complete")
 
@@ -272,6 +273,13 @@ func (c *vSphereProblemDetectorController) runSingleNodeSingleCheck(checkContext
 	}
 	nodeCheckTotalMetric.WithLabelValues(name, node.Name).Inc()
 	resultCollector.AddResult(res)
+}
+
+func (c *vSphereProblemDetectorController) finishNodeChecks() {
+	for i := range c.nodeChecks {
+		check := c.nodeChecks[i]
+		check.FinishCheck()
+	}
 }
 
 // reportResults sends events for all checks.


### PR DESCRIPTION
Call FinishCheck on all node checks when checks are complete. This allows various checks to report their metrics.

@openshift/storage 