### PR TITLE
Bug 1916379: Change metric for errors to gauge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+/vsphere-problem-detector

--- a/pkg/operator/metrics.go
+++ b/pkg/operator/metrics.go
@@ -23,10 +23,10 @@ var (
 		[]string{checkNameLabel},
 	)
 
-	clusterCheckErrrorMetric = metrics.NewCounterVec(
-		&metrics.CounterOpts{
-			Name:           "vsphere_cluster_check_errors_total",
-			Help:           "Number of failed vSphere cluster-level checks performed by vsphere-problem-detector.",
+	clusterCheckErrrorMetric = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Name:           "vsphere_cluster_check_errors",
+			Help:           "Indicates failing vSphere cluster-level checks performed by vsphere-problem-detector. Value of 1 means - a particular check is failing.",
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{checkNameLabel},
@@ -41,10 +41,10 @@ var (
 		[]string{checkNameLabel, nodeNameLabel},
 	)
 
-	nodeCheckErrrorMetric = metrics.NewCounterVec(
-		&metrics.CounterOpts{
-			Name:           "vsphere_node_check_errors_total",
-			Help:           "Number of failed vSphere node-level checks performed by vsphere-problem-detector.",
+	nodeCheckErrrorMetric = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Name:           "vsphere_node_check_errors",
+			Help:           "Indicates failing vSphere node-level checks performed by vsphere-problem-detector. Value of 1 means - a particular check is failing on a node.",
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{checkNameLabel, nodeNameLabel},

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -203,9 +203,10 @@ func (c *vSphereProblemDetectorController) runSingleClusterCheck(checkContext *c
 	err := checkFunc(checkContext)
 	if err != nil {
 		res.Error = err
-		clusterCheckErrrorMetric.WithLabelValues(name).Inc()
+		clusterCheckErrrorMetric.WithLabelValues(name).Set(1)
 		klog.V(2).Infof("%s failed: %s", name, err)
 	} else {
+		clusterCheckErrrorMetric.WithLabelValues(name).Set(0)
 		klog.V(2).Infof("%s passed", name)
 	}
 	clusterCheckTotalMetric.WithLabelValues(name).Inc()
@@ -265,9 +266,10 @@ func (c *vSphereProblemDetectorController) runSingleNodeSingleCheck(checkContext
 	err := check.CheckNode(checkContext, node, vm)
 	if err != nil {
 		res.Error = err
-		nodeCheckErrrorMetric.WithLabelValues(name, node.Name).Inc()
+		nodeCheckErrrorMetric.WithLabelValues(name, node.Name).Set(1)
 		klog.V(2).Infof("%s:%s failed: %s", name, node.Name, err)
 	} else {
+		nodeCheckErrrorMetric.WithLabelValues(name, node.Name).Set(0)
 		klog.V(2).Infof("%s:%s passed", name, node.Name)
 	}
 	nodeCheckTotalMetric.WithLabelValues(name, node.Name).Inc()


### PR DESCRIPTION
It is very tricky to report alerts on metrics that are emitted sporadically or at very long interval. Using gauge for this type simplifies alerting logic.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1916379

