### PR TITLE
Bug 1926943: Disable Datastore checks

### DIFF
--- a/pkg/check/interface.go
+++ b/pkg/check/interface.go
@@ -22,9 +22,11 @@ var (
 		"CheckTaskPermissions":   CheckTaskPermissions,
 		"ClusterInfo":            CollectClusterInfo,
 		"CheckFolderPermissions": CheckFolderPermissions,
-		"CheckDefaultDatastore":  CheckDefaultDatastore,
-		"CheckPVs":               CheckPVs,
-		"CheckStorageClasses":    CheckStorageClasses,
+		// TODO: Fix shortening of volume names in Kubernetes and enable these checks.
+		// See https://bugzilla.redhat.com/show_bug.cgi?id=1926943 for details.
+		// "CheckDefaultDatastore":  CheckDefaultDatastore,
+		// "CheckPVs":            CheckPVs,
+		// "CheckStorageClasses": CheckStorageClasses,
 	}
 	DefaultNodeChecks []NodeCheck = []NodeCheck{
 		&CheckNodeDiskUUID{},


### PR DESCRIPTION
The check is failing in our CI clusters, because their cluster ID has too many dashes, such as `ci-op-cvx98rqr-d1161-28xzd`

Full volume name then is `/var/lib/kubelet/plugins/kubernetes.io/vsphere-volume/mounts/[WorkloadDatastore]
00000000-0000-0000-0000-000000000000/ci-op-cvx98rqr-d1161-28xzd-dynamic-pvc-00000000-0000-0000-0000-000000000000.vmdk`, which, escaped by systemd, is over the limit of 255 characters.

This is temporary measure, we need to implement more strict cutting of cluster IDs in Kubernetes.