### PR TITLE
Check for a new line in credentials when unable to connect to vCenter

### DIFF
--- a/pkg/operator/metrics.go
+++ b/pkg/operator/metrics.go
@@ -8,6 +8,7 @@ import (
 const (
 	checkNameLabel = "check"
 	nodeNameLabel  = "node"
+	reasonLabel    = "reason"
 )
 
 // This file contains operator metrics, especially status of each check.
@@ -50,12 +51,13 @@ var (
 		[]string{checkNameLabel, nodeNameLabel},
 	)
 
-	syncErrrorMetric = metrics.NewGauge(
+	syncErrrorMetric = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
 			Name:           "vsphere_sync_errors",
 			Help:           "Indicates failing vSphere problem detector sync error. Value 1 means that the last sync failed.",
 			StabilityLevel: metrics.ALPHA,
 		},
+		[]string{reasonLabel},
 	)
 )
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -155,10 +155,10 @@ func (c *vSphereProblemDetectorController) sync(ctx context.Context, syncCtx fac
 		// E.g.: "failed to connect to vcenter.example.com: ServerFaultCode: Cannot complete login due to an incorrect user name or password."
 		availableCnd.Message = c.lastError.Error()
 		availableCnd.Reason = "SyncFailed"
-		syncErrrorMetric.Set(1)
+		syncErrrorMetric.WithLabelValues("SyncError").Set(1)
 	} else {
 		// Clean the error metric
-		syncErrrorMetric.Set(0)
+		syncErrrorMetric.WithLabelValues("SyncError").Set(1)
 	}
 
 	if _, _, updateErr := v1helpers.UpdateStatus(c.operatorClient,


### PR DESCRIPTION
# Description
Adding a check for a new line in credentials when unable to connect to vCenter.

# Testing
- Encode a credentials with `echo` and excluded `-n`.  For example:
~~~
echo mypassword | base64 -w0
~~~
- Update configmap `vsphere-creds` in `kube-system`
- Monitor vsphere-problem-detector logs
~~~
E0514 13:32:25.504764       1 operator.go:138] Failed to run checks: failed to connect to vcenter.domain.com: password in credentials contains new line
I0514 13:32:25.505070       1 operator.go:152] Scheduled the next check in 1m0.377112854s (2021-05-14 13:33:22.454966225 +0000 UTC m=+62.914630440)
~~~