### PR TITLE
Clear SyncError if there is no sync failure

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -158,7 +158,7 @@ func (c *vSphereProblemDetectorController) sync(ctx context.Context, syncCtx fac
 		syncErrrorMetric.WithLabelValues("SyncError").Set(1)
 	} else {
 		// Clean the error metric
-		syncErrrorMetric.WithLabelValues("SyncError").Set(1)
+		syncErrrorMetric.WithLabelValues("SyncError").Set(0)
 	}
 
 	if _, _, updateErr := v1helpers.UpdateStatus(c.operatorClient,


### PR DESCRIPTION
4.9 vSphere CI revealed a SyncErrors.  While reviewing the code that generates the sync error, a regression was found that was introduced in https://github.com/openshift/vsphere-problem-detector/pull/41.  The intent of this PR is resolve that regression by clearing the SyncError metric when there is no SyncError.