### PR TITLE
SPLAT-246: Specify user agent string for communication with vsphere

### DIFF
--- a/pkg/operator/vsphere_check.go
+++ b/pkg/operator/vsphere_check.go
@@ -299,7 +299,7 @@ func newClient(ctx context.Context, cfg *vsphere.VSphereConfig, username, passwo
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse config file: %s", err)
 	}
-	serverURL.User = url.UserPassword(username, password)
+
 	insecure := cfg.Global.InsecureFlag
 
 	tctx, cancel := context.WithTimeout(ctx, *check.Timeout)


### PR DESCRIPTION
Currently, the user agent string appears as `Go-http-client/1.1` in vCenter web client. This PR configures the user agent string so show vsphere-problem-detector is calling. 

NOTE: In order to show a useful version, tags will need to be created for this git repo; otherwise it will show `vsphere-problem-detector/v0.0.0-unknown`. 