### PR TITLE
Add version cli command

### DIFF
--- a/cmd/vsphere-problem-detector/main.go
+++ b/cmd/vsphere-problem-detector/main.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/component-base/logs"
 
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
-
 	"github.com/openshift/vsphere-problem-detector/pkg/operator"
 	"github.com/openshift/vsphere-problem-detector/pkg/version"
 )
@@ -49,7 +48,16 @@ func NewOperatorCommand() *cobra.Command {
 	ctrlCmd.Use = "start"
 	ctrlCmd.Short = "Start the vSphere Problem Detector"
 
+	versionCmd := &cobra.Command{
+		Use:	"version",
+		Short:  "Print the version number of vSphere Problem Detector",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(version.Get())
+		},
+	}
+
 	cmd.AddCommand(ctrlCmd)
+	cmd.AddCommand(versionCmd)
 
 	return cmd
 }


### PR DESCRIPTION
This is tangentially related to SPLAT-246 and https://github.com/openshift/vsphere-problem-detector/pull/58. 

NOTE: In order to show a useful version, tags will need to be created for this git repo; otherwise it will show:

```
$ ./vsphere-problem-detector version
v0.0.0-unknown
```