### PR TITLE
Updating vsphere-problem-detector images to be consistent with ART

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-8-release-golang-1.16-openshift-4.10
+  tag: rhel-8-release-golang-1.17-openshift-4.10

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.16-openshift-4.10 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10 AS builder
 WORKDIR /go/src/github.com/openshift/vsphere-problem-detector
 COPY . .
 ENV GO_PACKAGE github.com/openshift/vsphere-problem-detector

--- a/pkg/dependencymagnet/dependencymagnet.go
+++ b/pkg/dependencymagnet/dependencymagnet.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 // go mod won't pull in code that isn't depended upon, but we have some code we don't depend on from code that must be included


### PR DESCRIPTION
Reconciling with https://github.com/openshift/ocp-build-data/tree/5b89f5b601508a0bcc0399fd3f34b7aa2e86e90e/images/vsphere-problem-detector.yml
Replaces https://github.com/openshift/vsphere-problem-detector/pull/62
/cc @openshift/storage 