### PR TITLE
Bug 2051881: Dont forget to register metrics before emitting

### DIFF
--- a/pkg/check/count_pv_types.go
+++ b/pkg/check/count_pv_types.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 
 	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
 )
 
 const (
@@ -21,6 +22,10 @@ var (
 	)
 	rwxVolumeRegx = regexp.MustCompile(`file\:`)
 )
+
+func init() {
+	legacyregistry.MustRegister(rwxPVCountMetric)
+}
 
 func CountRWXVolumes(ctx *CheckContext) error {
 	rwxPVCount, err := countRWXPVsFromCluster(ctx)


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2051881

Working metric:

```
{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"vsphere_rwx_volumes_total","container":"vsphere-problem-detector-operator","endpoint":"vsphere-metrics","job":"vsphere-problem-detector-metrics","namespace":"openshift-c
luster-storage-operator","pod":"vsphere-problem-detector-operator-5b6c67f8df-76ncr","service":"vsphere-problem-detector-metrics"},"value":[1644347281.224,"2"]}]}}
```

