### PR TITLE
Fix stale metric collection

### DIFF
--- a/pkg/check/datastore.go
+++ b/pkg/check/datastore.go
@@ -76,6 +76,9 @@ func (d dataStoreTypeCollector) getDataStoreTypeCount() map[string]int {
 
 // CheckStorageClasses tests that datastore name in all StorageClasses in the cluster is short enough.
 func CheckStorageClasses(ctx *CheckContext) error {
+	// reset the metric so as if types have changed we don't emit them again
+	dataStoreTypesMetric.Reset()
+
 	infra, err := ctx.KubeClient.GetInfrastructure(ctx.Context)
 	if err != nil {
 		return err

--- a/pkg/check/info.go
+++ b/pkg/check/info.go
@@ -29,6 +29,7 @@ func init() {
 // CollectClusterInfo grabs information about vSphere cluster and updates corresponding metrics.
 // It's not a vSphere check per se, just using the interface.
 func CollectClusterInfo(ctx *CheckContext) error {
+	vCenterInfoMetric.Reset()
 	collectVCenterInfo(ctx)
 	return nil
 }

--- a/pkg/check/node_esxi_version.go
+++ b/pkg/check/node_esxi_version.go
@@ -39,6 +39,7 @@ func (c *CollectNodeESXiVersion) Name() string {
 }
 
 func (c *CollectNodeESXiVersion) StartCheck() error {
+	esxiVersionMetric.Reset()
 	return nil
 }
 

--- a/pkg/check/node_hw_version.go
+++ b/pkg/check/node_hw_version.go
@@ -38,6 +38,7 @@ func (c *CollectNodeHWVersion) Name() string {
 }
 
 func (c *CollectNodeHWVersion) StartCheck() error {
+	hwVersionMetric.Reset()
 	return nil
 }
 


### PR DESCRIPTION
Resetting the metrics prevents old gauges from being emitted.

Before:

```
~> oc exec deployment/vsphere-problem-detector-operator -- curl -ks -H "Authorization: Bearer $token" https://vsphere-problem-detector-metrics:8444/metrics|grep "node_hw"
# HELP vsphere_node_hw_version_total [ALPHA] Number of vSphere nodes with given HW version.                                                                                                                         
# TYPE vsphere_node_hw_version_total gauge                                                                                                                                                                          
vsphere_node_hw_version_total{hw_version="vmx-13"} 1                                                                                                                                                                
vsphere_node_hw_version_total{hw_version="vmx-15"} 6                                                                                                                                                                
```

Move one of the nodes to hw-15 and make sure vsphere-problem-detector is not restarted:

```
~> oc exec deployment/vsphere-problem-detector-operator -- curl -ks -H "Authorization: Bearer $token" https://vsphere-problem-detector-metrics:8444/metrics|grep "node_hw"
# HELP vsphere_node_hw_version_total [ALPHA] Number of vSphere nodes with given HW version.
# TYPE vsphere_node_hw_version_total gauge
vsphere_node_hw_version_total{hw_version="vmx-15"} 7
```
