### PR TITLE
Bug 2092811:Lets remove datastore length checks for now

### DIFF
--- a/pkg/check/interface.go
+++ b/pkg/check/interface.go
@@ -20,13 +20,10 @@ var (
 
 	// DefaultClusterChecks is the list of all checks.
 	DefaultClusterChecks map[string]ClusterCheck = map[string]ClusterCheck{
-		"CheckTaskPermissions":   CheckTaskPermissions,
-		"ClusterInfo":            CollectClusterInfo,
-		"CheckFolderPermissions": CheckFolderPermissions,
-		"CheckDefaultDatastore":  CheckDefaultDatastore,
-		// PV checks are disabled because existing PVs can't be fixed easily and it could be problematic
-		// to keep alerting on them
-		// "CheckPVs":               CheckPVs,
+		"CheckTaskPermissions":    CheckTaskPermissions,
+		"ClusterInfo":             CollectClusterInfo,
+		"CheckFolderPermissions":  CheckFolderPermissions,
+		"CheckDefaultDatastore":   CheckDefaultDatastore,
 		"CheckStorageClasses":     CheckStorageClasses,
 		"CountRWXVolumes":         CountRWXVolumes,
 		"CheckAccountPermissions": CheckAccountPermissions,


### PR DESCRIPTION
With CSI it will become less relevant and only solution is basically renaming the datastore(which breaks existing PV).

As for systemd, it just means that systemd is not managing those mount point as units. But I don't think it is necessary in this case because kubelet is already doing it.

Fixes https://issues.redhat.com/browse/OCPBUGSM-44982