### PR TITLE
OCPBUGS-10794: Add build number to metrics

### DIFF
--- a/pkg/check/info.go
+++ b/pkg/check/info.go
@@ -7,6 +7,7 @@ import (
 
 const (
 	versionLabel    = "version"
+	buildLabel      = "build"
 	apiVersionLabel = "api_version"
 	vCenterUUID     = "uuid"
 )
@@ -18,7 +19,7 @@ var (
 			Help:           "Information about vSphere vCenter.",
 			StabilityLevel: metrics.ALPHA,
 		},
-		[]string{versionLabel, apiVersionLabel, vCenterUUID},
+		[]string{versionLabel, apiVersionLabel, vCenterUUID, buildLabel},
 	)
 )
 
@@ -37,7 +38,8 @@ func CollectClusterInfo(ctx *CheckContext) error {
 func collectVCenterInfo(ctx *CheckContext) {
 	version := ctx.VMClient.ServiceContent.About.Version
 	apiVersion := ctx.VMClient.ServiceContent.About.ApiVersion
+	build := ctx.VMClient.ServiceContent.About.Build
 	uuid := ctx.VMClient.ServiceContent.About.InstanceUuid
 	ctx.ClusterInfo.SetVCenterVersion(version, apiVersion)
-	vCenterInfoMetric.WithLabelValues(version, apiVersion, uuid).Set(1.0)
+	vCenterInfoMetric.WithLabelValues(version, apiVersion, uuid, build).Set(1.0)
 }

--- a/pkg/check/info_test.go
+++ b/pkg/check/info_test.go
@@ -24,7 +24,7 @@ func TestInfo(t *testing.T) {
 	expectedMetric := `
         # HELP vsphere_vcenter_info [ALPHA] Information about vSphere vCenter.
         # TYPE vsphere_vcenter_info gauge
-        vsphere_vcenter_info{api_version="6.5", uuid="dbed6e0c-bd88-4ef6-b594-21283e1c677f",version="6.5.0"} 1
+        vsphere_vcenter_info{api_version="6.5", build="5973321", uuid="dbed6e0c-bd88-4ef6-b594-21283e1c677f",version="6.5.0"} 1
 `
 
 	if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(expectedMetric), "vsphere_vcenter_info"); err != nil {


### PR DESCRIPTION
This commit adds a single metric - vcenter build
number. This will help us determine the exact
vcenter release a customer is using.