### PR TITLE
OCPBUGS-14029: In UPI clusters VSphere platform could be nil

### DIFF
--- a/pkg/check/zones_test.go
+++ b/pkg/check/zones_test.go
@@ -3,12 +3,14 @@ package check
 import (
 	"errors"
 	"fmt"
-	"github.com/vmware/govmomi/find"
 	"testing"
 
-	"github.com/openshift/api/config/v1"
+	"github.com/vmware/govmomi/find"
+
 	"github.com/stretchr/testify/assert"
 	vapitags "github.com/vmware/govmomi/vapi/tags"
+
+	"github.com/openshift/api/config/v1"
 )
 
 const (
@@ -185,6 +187,14 @@ func TestValidate(t *testing.T) {
 		infrastructure: func() *v1.Infrastructure {
 			inf := validInfrastructure()
 			inf.Spec.PlatformSpec.VSphere.FailureDomains = nil
+			return inf
+		}(),
+	}, {
+		name:                "multi-zone validation - VSphere nil - No tags",
+		checkZoneTagsMethod: CheckZoneTags,
+		infrastructure: func() *v1.Infrastructure {
+			inf := validInfrastructure()
+			inf.Spec.PlatformSpec.VSphere = nil
 			return inf
 		}(),
 	}, {


### PR DESCRIPTION
This PR resolves an issue when `vsphere`

```
platformSpec:
  type: VSphere
  vsphere: {}
```

is unset.

- Adds a check for `inf.Spec.PlatformSpec.VSphere`, logs and returns if nil.

- Adds a additional unit test to check this condition.