### PR TITLE
OCPBUGS-7413: Use collector for ephemeral metrics

### DIFF
--- a/pkg/check/framework_test.go
+++ b/pkg/check/framework_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/session"
 	"github.com/vmware/govmomi/simulator"
+
 	// required to initialize the REST endpoint.
 	_ "github.com/vmware/govmomi/vapi/rest"
 	// required to initialize the VAPI endpoint.

--- a/pkg/check/interface.go
+++ b/pkg/check/interface.go
@@ -13,6 +13,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/legacy-cloud-providers/vsphere"
 
+	"github.com/openshift/vsphere-problem-detector/pkg/metrics"
 	"github.com/openshift/vsphere-problem-detector/pkg/util"
 )
 
@@ -34,18 +35,12 @@ var (
 	DefaultNodeChecks []NodeCheck = []NodeCheck{
 		&CheckNodeDiskUUID{},
 		&CheckNodeProviderID{},
-		&CollectNodeHWVersion{
-			lastMetricEmission: map[string]int{},
-		},
-		&CollectNodeESXiVersion{
-			lastMetricEmission: make(map[[2]string]int),
-		},
+		&CollectNodeHWVersion{},
+		&CollectNodeESXiVersion{},
 		&CheckNodeDiskPerf{},
 		&CheckComputeClusterPermissions{},
 		&CheckResourcePoolPermissions{},
-		&CollectNodeCBT{
-			lastMetricEmission: map[string]int{},
-		},
+		&CollectNodeCBT{},
 	}
 
 	// NodeProperties is a list of properties that NodeCheck can rely on to be pre-filled.
@@ -66,15 +61,16 @@ type KubeClient interface {
 }
 
 type CheckContext struct {
-	Context     context.Context
-	VMConfig    *vsphere.VSphereConfig
-	VMClient    *vim25.Client
-	TagManager  *vapitags.Manager
-	Username    string
-	AuthManager AuthManager
-	KubeClient  KubeClient
-	ClusterInfo *util.ClusterInfo
-	Cache       VSphereCache
+	Context          context.Context
+	VMConfig         *vsphere.VSphereConfig
+	VMClient         *vim25.Client
+	TagManager       *vapitags.Manager
+	Username         string
+	AuthManager      AuthManager
+	KubeClient       KubeClient
+	ClusterInfo      *util.ClusterInfo
+	Cache            VSphereCache
+	MetricsCollector *metrics.Collector
 }
 
 // Interface of a single vSphere cluster-level check. It gets connection to vSphere, vSphere config and connection to Kubernetes.

--- a/pkg/check/node_cbt.go
+++ b/pkg/check/node_cbt.go
@@ -4,16 +4,15 @@ import (
 	"fmt"
 	"strings"
 
+	lmetric "github.com/openshift/vsphere-problem-detector/pkg/metrics"
 	"github.com/vmware/govmomi/vim25/mo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/component-base/metrics"
-	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
 )
 
 // CollectNodeCBT emits metric with CBT Config of each VM
 type CollectNodeCBT struct {
-	lastMetricEmission map[string]int
 }
 
 var _ NodeCheck = &CollectNodeCBT{}
@@ -24,21 +23,6 @@ const (
 	cbtEnabledKey    = "enabled"
 	cbtDisabledKey   = "disabled"
 )
-
-var (
-	cbtMismatchMetric = metrics.NewGaugeVec(
-		&metrics.GaugeOpts{
-			Name:           "vsphere_vm_cbt_checks",
-			Help:           "Boolean metric based on whether ctkEnabled is consistent or not across all nodes in the cluster.",
-			StabilityLevel: metrics.ALPHA,
-		},
-		[]string{cbtMismatchLabel},
-	)
-)
-
-func init() {
-	legacyregistry.MustRegister(cbtMismatchMetric)
-}
 
 func (c *CollectNodeCBT) Name() string {
 	return "CollectNodeCBT"
@@ -75,21 +59,11 @@ func (c *CollectNodeCBT) CheckNode(ctx *CheckContext, node *v1.Node, vm *mo.Virt
 func (c *CollectNodeCBT) FinishCheck(ctx *CheckContext) {
 	cbtData := ctx.ClusterInfo.GetCbtData()
 
-	for k := range c.lastMetricEmission {
-		c.lastMetricEmission[k] = 0
-	}
-
 	klog.V(2).Infof("Enabled (%v) Disabled (%v)", cbtData[cbtEnabledKey], cbtData[cbtDisabledKey])
 	// Set the counts of enabled vs disabled
 	for cbtEnabled, count := range cbtData {
 		klog.V(4).Infof("CBT (%v): %v", cbtEnabled, count)
-		c.lastMetricEmission[cbtEnabled] = count
-		cbtMismatchMetric.WithLabelValues(cbtEnabled).Set(float64(count))
-	}
-
-	for k, v := range c.lastMetricEmission {
-		if v == 0 {
-			cbtMismatchMetric.WithLabelValues(k).Set(0)
-		}
+		m := metrics.NewLazyConstMetric(lmetric.CbtMismatchMetric, metrics.GaugeValue, float64(count), cbtEnabled)
+		ctx.MetricsCollector.AddMetric(m)
 	}
 }

--- a/pkg/check/node_cbt_test.go
+++ b/pkg/check/node_cbt_test.go
@@ -193,6 +193,7 @@ func TestVmCbtProperties(t *testing.T) {
 			}
 
 			check.FinishCheck(simctx)
+			collector.FinishedAllChecks()
 
 			// Verify metrics
 			if err := testutil.GatherAndCompare(customRegistry, strings.NewReader(test.expectedMetrics), "vsphere_vm_cbt_checks"); err != nil {

--- a/pkg/check/node_cbt_test.go
+++ b/pkg/check/node_cbt_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/openshift/vsphere-problem-detector/pkg/metrics"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/component-base/metrics/legacyregistry"
+	basemetrics "k8s.io/component-base/metrics"
 )
 
 var (
@@ -167,9 +168,11 @@ func TestVmCbtProperties(t *testing.T) {
 				t.Fatalf("setupSimulator failed: %s", err)
 			}
 			defer cleanup()
+			collector := metrics.NewMetricsCollector()
+			simctx.MetricsCollector = collector
 
-			// Reset metrics from previous tests. Note: the tests can't run in parallel!
-			legacyregistry.Reset()
+			customRegistry := basemetrics.NewKubeRegistry()
+			customRegistry.CustomMustRegister(collector)
 
 			// Act - simulate loop through all nodes
 			err = check.StartCheck()
@@ -192,7 +195,7 @@ func TestVmCbtProperties(t *testing.T) {
 			check.FinishCheck(simctx)
 
 			// Verify metrics
-			if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(test.expectedMetrics), "vsphere_vm_cbt_checks"); err != nil {
+			if err := testutil.GatherAndCompare(customRegistry, strings.NewReader(test.expectedMetrics), "vsphere_vm_cbt_checks"); err != nil {
 				t.Errorf("Unexpected metric: %s", err)
 			}
 		})

--- a/pkg/check/node_cbt_test.go
+++ b/pkg/check/node_cbt_test.go
@@ -160,9 +160,7 @@ func TestVmCbtProperties(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Stage
-			check := CollectNodeCBT{
-				lastMetricEmission: map[string]int{},
-			}
+			check := CollectNodeCBT{}
 
 			simctx, cleanup, err := setupSimulator(test.kubeClient, defaultModel)
 			if err != nil {

--- a/pkg/check/node_esxi_version.go
+++ b/pkg/check/node_esxi_version.go
@@ -74,5 +74,4 @@ func (c *CollectNodeESXiVersion) FinishCheck(ctx *CheckContext) {
 		m := metrics.NewLazyConstMetric(lmetric.EsxiVersionMetric, metrics.GaugeValue, float64(count), v.Version, v.APIVersion)
 		ctx.MetricsCollector.AddMetric(m)
 	}
-	return
 }

--- a/pkg/check/node_esxi_version.go
+++ b/pkg/check/node_esxi_version.go
@@ -4,36 +4,20 @@ import (
 	"context"
 	"fmt"
 
+	lmetric "github.com/openshift/vsphere-problem-detector/pkg/metrics"
 	"github.com/openshift/vsphere-problem-detector/pkg/util"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/vim25/mo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/component-base/metrics"
-	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
 )
 
 // CollectNodeESXiVersion emits metric with version of each ESXi host that runs at least a single VM with node.
 type CollectNodeESXiVersion struct {
-	lastMetricEmission map[[2]string]int
 }
 
 var _ NodeCheck = &CollectNodeESXiVersion{}
-
-var (
-	esxiVersionMetric = metrics.NewGaugeVec(
-		&metrics.GaugeOpts{
-			Name:           "vsphere_esxi_version_total",
-			Help:           "Number of ESXi hosts with given version.",
-			StabilityLevel: metrics.ALPHA,
-		},
-		[]string{versionLabel, apiVersionLabel},
-	)
-)
-
-func init() {
-	legacyregistry.MustRegister(esxiVersionMetric)
-}
 
 func (c *CollectNodeESXiVersion) Name() string {
 	return "CollectNodeESXiVersion"
@@ -79,9 +63,6 @@ func (c *CollectNodeESXiVersion) CheckNode(ctx *CheckContext, node *v1.Node, vm 
 
 func (c *CollectNodeESXiVersion) FinishCheck(ctx *CheckContext) {
 	versions := make(map[util.ESXiVersionInfo]int)
-	for k := range c.lastMetricEmission {
-		c.lastMetricEmission[k] = 0
-	}
 
 	esxiVersions := ctx.ClusterInfo.GetHostVersions()
 	for _, v := range esxiVersions {
@@ -90,15 +71,8 @@ func (c *CollectNodeESXiVersion) FinishCheck(ctx *CheckContext) {
 
 	// Report the count
 	for v, count := range versions {
-		esxiVersionMetric.WithLabelValues(v.Version, v.APIVersion).Set(float64(count))
-		c.lastMetricEmission[[2]string{v.Version, v.APIVersion}] = count
+		m := metrics.NewLazyConstMetric(lmetric.EsxiVersionMetric, metrics.GaugeValue, float64(count), v.Version, v.APIVersion)
+		ctx.MetricsCollector.AddMetric(m)
 	}
-
-	for k, v := range c.lastMetricEmission {
-		if v == 0 {
-			esxiVersionMetric.WithLabelValues(k[0], k[1]).Set(0)
-		}
-	}
-
 	return
 }

--- a/pkg/check/node_esxi_version_test.go
+++ b/pkg/check/node_esxi_version_test.go
@@ -40,9 +40,7 @@ func TestCollectNodeESXiVersion(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Stage
-			check := CollectNodeESXiVersion{
-				lastMetricEmission: map[[2]string]int{},
-			}
+			check := CollectNodeESXiVersion{}
 			kubeClient := &fakeKubeClient{
 				nodes: defaultNodes(),
 			}

--- a/pkg/check/node_esxi_version_test.go
+++ b/pkg/check/node_esxi_version_test.go
@@ -4,8 +4,9 @@ import (
 	"strings"
 	"testing"
 
-	testutil "github.com/prometheus/client_golang/prometheus/testutil"
-	"k8s.io/component-base/metrics/legacyregistry"
+	"github.com/openshift/vsphere-problem-detector/pkg/metrics"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	basemetrics "k8s.io/component-base/metrics"
 )
 
 func TestCollectNodeESXiVersion(t *testing.T) {
@@ -49,6 +50,8 @@ func TestCollectNodeESXiVersion(t *testing.T) {
 				t.Fatalf("setupSimulator failed: %s", err)
 			}
 			defer cleanup()
+			collector := metrics.NewMetricsCollector()
+			ctx.MetricsCollector = collector
 
 			// Set esxi version of the only host.
 			err = customizeHostVersion(defaultHostId, test.esxiVersion, test.esxiApiversion)
@@ -57,7 +60,9 @@ func TestCollectNodeESXiVersion(t *testing.T) {
 			}
 
 			// Reset metrics from previous tests. Note: the tests can't run in parallel!
-			legacyregistry.Reset()
+			// legacyregistry.Reset()
+			customRegistry := basemetrics.NewKubeRegistry()
+			customRegistry.CustomMustRegister(collector)
 
 			// Act - simulate loop through all nodes
 			err = check.StartCheck()
@@ -79,7 +84,7 @@ func TestCollectNodeESXiVersion(t *testing.T) {
 			check.FinishCheck(ctx)
 
 			// Assert
-			if err := testutil.GatherAndCompare(legacyregistry.DefaultGatherer, strings.NewReader(test.expectedMetrics), "vsphere_esxi_version_total"); err != nil {
+			if err := testutil.GatherAndCompare(customRegistry, strings.NewReader(test.expectedMetrics), "vsphere_esxi_version_total"); err != nil {
 				t.Errorf("Unexpected metric: %s", err)
 			}
 		})

--- a/pkg/check/node_esxi_version_test.go
+++ b/pkg/check/node_esxi_version_test.go
@@ -82,6 +82,7 @@ func TestCollectNodeESXiVersion(t *testing.T) {
 			}
 
 			check.FinishCheck(ctx)
+			collector.FinishedAllChecks()
 
 			// Assert
 			if err := testutil.GatherAndCompare(customRegistry, strings.NewReader(test.expectedMetrics), "vsphere_esxi_version_total"); err != nil {

--- a/pkg/check/node_hw_version.go
+++ b/pkg/check/node_hw_version.go
@@ -5,7 +5,6 @@ import (
 	"github.com/vmware/govmomi/vim25/mo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/component-base/metrics"
-	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/klog/v2"
 )
 
@@ -14,25 +13,6 @@ type CollectNodeHWVersion struct {
 }
 
 var _ NodeCheck = &CollectNodeHWVersion{}
-
-const (
-	hwVersionLabel = "hw_version"
-)
-
-var (
-	hwVersionMetric = metrics.NewGaugeVec(
-		&metrics.GaugeOpts{
-			Name:           "vsphere_node_hw_version_total",
-			Help:           "Number of vSphere nodes with given HW version.",
-			StabilityLevel: metrics.ALPHA,
-		},
-		[]string{hwVersionLabel},
-	)
-)
-
-func init() {
-	legacyregistry.MustRegister(hwVersionMetric)
-}
 
 func (c *CollectNodeHWVersion) Name() string {
 	return "CollectNodeHWVersion"
@@ -56,5 +36,4 @@ func (c *CollectNodeHWVersion) FinishCheck(ctx *CheckContext) {
 		m := metrics.NewLazyConstMetric(lmetric.HwVersionMetric, metrics.GaugeValue, float64(count), hwVersion)
 		ctx.MetricsCollector.AddMetric(m)
 	}
-	return
 }

--- a/pkg/check/node_hw_version.go
+++ b/pkg/check/node_hw_version.go
@@ -1,6 +1,7 @@
 package check
 
 import (
+	lmetric "github.com/openshift/vsphere-problem-detector/pkg/metrics"
 	"github.com/vmware/govmomi/vim25/mo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/component-base/metrics"
@@ -10,7 +11,6 @@ import (
 
 // CollectNodeHWVersion emits metric with HW version of each VM
 type CollectNodeHWVersion struct {
-	lastMetricEmission map[string]int
 }
 
 var _ NodeCheck = &CollectNodeHWVersion{}
@@ -52,19 +52,9 @@ func (c *CollectNodeHWVersion) CheckNode(ctx *CheckContext, node *v1.Node, vm *m
 func (c *CollectNodeHWVersion) FinishCheck(ctx *CheckContext) {
 	hwversions := ctx.ClusterInfo.GetHardwareVersion()
 
-	for k := range c.lastMetricEmission {
-		c.lastMetricEmission[k] = 0
-	}
-
 	for hwVersion, count := range hwversions {
-		c.lastMetricEmission[hwVersion] = count
-		hwVersionMetric.WithLabelValues(hwVersion).Set(float64(count))
-	}
-
-	for k, v := range c.lastMetricEmission {
-		if v == 0 {
-			hwVersionMetric.WithLabelValues(k).Set(0)
-		}
+		m := metrics.NewLazyConstMetric(lmetric.HwVersionMetric, metrics.GaugeValue, float64(count), hwVersion)
+		ctx.MetricsCollector.AddMetric(m)
 	}
 	return
 }

--- a/pkg/check/node_hw_version_test.go
+++ b/pkg/check/node_hw_version_test.go
@@ -93,6 +93,7 @@ vsphere_node_hw_version_total{hw_version="vmx-15"} 2
 			}
 
 			check.FinishCheck(ctx)
+			collector.FinishedAllChecks()
 
 			// Assert
 			if err := testutil.GatherAndCompare(customRegistry, strings.NewReader(test.expectedMetrics), "vsphere_node_hw_version_total"); err != nil {

--- a/pkg/check/node_hw_version_test.go
+++ b/pkg/check/node_hw_version_test.go
@@ -52,11 +52,8 @@ vsphere_node_hw_version_total{hw_version="vmx-15"} 2
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			// Stage
-			check := CollectNodeHWVersion{
-				lastMetricEmission: map[string]int{},
-			}
+			check := CollectNodeHWVersion{}
 			if len(test.initialMetric) > 0 {
-				check.lastMetricEmission = test.initialMetric
 			}
 
 			kubeClient := &fakeKubeClient{

--- a/pkg/metrics/collector.go
+++ b/pkg/metrics/collector.go
@@ -1,0 +1,73 @@
+package metrics
+
+import (
+	"k8s.io/component-base/metrics"
+)
+
+type Collector struct {
+	metrics.BaseStableCollector
+
+	storedMetrics []metrics.Metric
+}
+
+var _ metrics.StableCollector = &Collector{}
+
+const (
+	VersionLabel    = "version"
+	BuildLabel      = "build"
+	ApiVersionLabel = "api_version"
+	vCenterUUID     = "uuid"
+
+	HwVersionLabel   = "hw_version"
+	cbtMismatchLabel = "cbt"
+)
+
+// Metrics in this package can be used when we expect metrics with certain label to stop
+// being reported when cluster configuration changes.
+var (
+	EsxiVersionMetric = metrics.NewDesc(
+		"vsphere_esxi_version_total",
+		"Number of ESXi hosts with given version.",
+		[]string{VersionLabel, ApiVersionLabel}, nil,
+		metrics.ALPHA, "",
+	)
+	HwVersionMetric = metrics.NewDesc(
+		"vsphere_node_hw_version_total",
+		"Number of vSphere nodes with given HW version.",
+		[]string{HwVersionLabel}, nil,
+		metrics.ALPHA, "",
+	)
+
+	CbtMismatchMetric = metrics.NewDesc(
+		"vsphere_vm_cbt_checks",
+		"Boolean metric based on whether ctkEnabled is consistent or not across all nodes in the cluster.",
+		[]string{cbtMismatchLabel}, nil,
+		metrics.ALPHA, "",
+	)
+)
+
+func NewMetricsCollector() *Collector {
+	return &Collector{
+		storedMetrics: []metrics.Metric{},
+	}
+}
+
+func (c *Collector) DescribeWithStability(ch chan<- *metrics.Desc) {
+	ch <- EsxiVersionMetric
+	ch <- HwVersionMetric
+	ch <- CbtMismatchMetric
+}
+
+func (c *Collector) CollectWithStability(ch chan<- metrics.Metric) {
+	for _, m := range c.storedMetrics {
+		ch <- m
+	}
+}
+
+func (c *Collector) AddMetric(m metrics.Metric) {
+	c.storedMetrics = append(c.storedMetrics, m)
+}
+
+func (c *Collector) ClearStoredMetric() {
+	c.storedMetrics = []metrics.Metric{}
+}

--- a/pkg/metrics/collector_test.go
+++ b/pkg/metrics/collector_test.go
@@ -1,0 +1,96 @@
+package metrics
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"k8s.io/component-base/metrics"
+)
+
+func TestCollector(t *testing.T) {
+	tests := []struct {
+		name             string
+		collectorModFunc func(c *Collector) *Collector
+		emittedMetric    func() metrics.Metric
+		expectedMetrics  string
+	}{
+		{
+			name: "should report stale metric when metrics are marked stale",
+			collectorModFunc: func(c *Collector) *Collector {
+				c.ClearStoredMetric()
+				return c
+			},
+			emittedMetric: func() metrics.Metric {
+				return metrics.NewLazyConstMetric(EsxiVersionMetric, metrics.GaugeValue, float64(10), "7.0", "7.0.2")
+			},
+			expectedMetrics: `
+			# HELP vsphere_esxi_version_total [ALPHA] Number of ESXi hosts with given version.
+			# TYPE vsphere_esxi_version_total gauge
+			vsphere_esxi_version_total{api_version="7.0.2", version="7.0"} 10
+			`,
+		},
+		{
+			name: "marking metrics stale twice should still result in metrics being reported",
+			collectorModFunc: func(c *Collector) *Collector {
+				c.ClearStoredMetric()
+				c.ClearStoredMetric()
+				return c
+			},
+			emittedMetric: func() metrics.Metric {
+				return metrics.NewLazyConstMetric(EsxiVersionMetric, metrics.GaugeValue, float64(10), "7.0", "7.0.2")
+			},
+			expectedMetrics: `
+			# HELP vsphere_esxi_version_total [ALPHA] Number of ESXi hosts with given version.
+			# TYPE vsphere_esxi_version_total gauge
+			vsphere_esxi_version_total{api_version="7.0.2", version="7.0"} 10
+			`,
+		},
+		{
+			name: "finishing all checks should result in fresh metrics",
+			collectorModFunc: func(c *Collector) *Collector {
+				c.ClearStoredMetric()
+				m := metrics.NewLazyConstMetric(EsxiVersionMetric, metrics.GaugeValue, float64(10), "8.0", "8.0.2")
+				c.AddMetric(m)
+				c.FinishedAllChecks()
+				return c
+			},
+			emittedMetric: func() metrics.Metric {
+				return metrics.NewLazyConstMetric(EsxiVersionMetric, metrics.GaugeValue, float64(10), "7.0", "7.0.2")
+			},
+			expectedMetrics: `
+			# HELP vsphere_esxi_version_total [ALPHA] Number of ESXi hosts with given version.
+			# TYPE vsphere_esxi_version_total gauge
+			vsphere_esxi_version_total{api_version="8.0.2", version="8.0"} 10
+			`,
+		},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			collector := NewMetricsCollector()
+			ch := make(chan metrics.Metric)
+
+			customRegistry := metrics.NewKubeRegistry()
+			customRegistry.CustomMustRegister(collector)
+
+			collectedMetrics := []metrics.Metric{}
+
+			go func() {
+				for m := range ch {
+					collectedMetrics = append(collectedMetrics, m)
+				}
+			}()
+			collector.AddMetric(test.emittedMetric())
+			collector = test.collectorModFunc(collector)
+
+			collector.CollectWithStability(ch)
+			close(ch)
+			// Assert
+			if err := testutil.GatherAndCompare(customRegistry, strings.NewReader(test.expectedMetrics), "vsphere_esxi_version_total"); err != nil {
+				t.Errorf("Unexpected metric: %s", err)
+			}
+		})
+	}
+}

--- a/pkg/metrics/collector_test.go
+++ b/pkg/metrics/collector_test.go
@@ -16,9 +16,9 @@ func TestCollector(t *testing.T) {
 		expectedMetrics  string
 	}{
 		{
-			name: "should report stale metric when metrics are marked stale",
+			name: "should report old metrics when checks are still running",
 			collectorModFunc: func(c *Collector) *Collector {
-				c.ClearStoredMetric()
+				c.StartMetricCollection()
 				return c
 			},
 			emittedMetric: func() metrics.Metric {
@@ -33,8 +33,8 @@ func TestCollector(t *testing.T) {
 		{
 			name: "marking metrics stale twice should still result in metrics being reported",
 			collectorModFunc: func(c *Collector) *Collector {
-				c.ClearStoredMetric()
-				c.ClearStoredMetric()
+				c.StartMetricCollection()
+				c.StartMetricCollection()
 				return c
 			},
 			emittedMetric: func() metrics.Metric {
@@ -49,7 +49,7 @@ func TestCollector(t *testing.T) {
 		{
 			name: "finishing all checks should result in fresh metrics",
 			collectorModFunc: func(c *Collector) *Collector {
-				c.ClearStoredMetric()
+				c.StartMetricCollection()
 				m := metrics.NewLazyConstMetric(EsxiVersionMetric, metrics.GaugeValue, float64(10), "8.0", "8.0.2")
 				c.AddMetric(m)
 				c.FinishedAllChecks()
@@ -83,6 +83,8 @@ func TestCollector(t *testing.T) {
 				}
 			}()
 			collector.AddMetric(test.emittedMetric())
+			collector.FinishedAllChecks()
+
 			collector = test.collectorModFunc(collector)
 
 			collector.CollectWithStability(ch)

--- a/pkg/operator/vsphere_check.go
+++ b/pkg/operator/vsphere_check.go
@@ -87,9 +87,12 @@ func (v *vSphereChecker) runChecks(ctx context.Context, clusterInfo *util.Cluste
 
 	klog.V(4).Infof("Waiting for all checks")
 	if err := checkRunner.Wait(ctx); err != nil {
+		klog.Errorf("error waiting for metrics checks to finish: %v", err)
 		return resultCollector, err
 	}
 	v.finishNodeChecks(checkContext)
+	klog.Infof("Finished running all vSphere specific checks in the cluster")
+	v.controller.metricsCollector.FinishedAllChecks()
 	return resultCollector, nil
 }
 


### PR DESCRIPTION
This change frees up individual check from storing the metrics that can change and need not be emitted anymore.


Fixes OCPBUGS-7413