### PR TITLE
OCPBUGS-34563: Drop event when CheckDefaultDatastore fails

### DIFF
--- a/pkg/check/datastore.go
+++ b/pkg/check/datastore.go
@@ -363,7 +363,8 @@ func checkForDatastoreCluster(ctx *CheckContext, dsMo mo.Datastore, dataStoreNam
 				continue
 			}
 			if tDS.Summary.Url == dsMo.Summary.Url {
-				return fmt.Errorf("datastore %s is part of %s datastore cluster", tDS.Summary.Name, ds.Summary.Name)
+				klog.Warningf("datastore %s is part of %s datastore cluster", tDS.Summary.Name, ds.Summary.Name)
+				continue
 			}
 		}
 	}

--- a/pkg/check/datastore_test.go
+++ b/pkg/check/datastore_test.go
@@ -44,7 +44,7 @@ var (
 		{
 			name:        "datastore which is part of a datastore cluster",
 			datastore:   "/DC0/datastore/DC0_POD0/LocalDS_2",
-			expectError: true,
+			expectError: false, // we only log a warning
 			dsType:      "OTHER",
 		},
 		{


### PR DESCRIPTION
Log a warning instead.

CC @openshift/storage
