### PR TITLE
Revert #166 "STOR-1767: Make checks less frequent if State is Removed in ClusterCSIDriver"

### DIFF
--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -8,7 +8,6 @@ import (
 	configinformer "github.com/openshift/client-go/config/informers/externalversions"
 	operatorclient "github.com/openshift/client-go/operator/clientset/versioned"
 	informer "github.com/openshift/client-go/operator/informers/externalversions"
-	operatorinformers "github.com/openshift/client-go/operator/informers/externalversions"
 	"github.com/openshift/library-go/pkg/controller/controllercmd"
 	"github.com/openshift/library-go/pkg/operator/loglevel"
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
@@ -48,16 +47,12 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 	}
 	configInformers := configinformer.NewSharedInformerFactoryWithOptions(configClient, resync)
 
-	operatorInformer := operatorinformers.NewSharedInformerFactory(csiConfigClient, 20*time.Minute)
-	clusterCSIDriverInformer := operatorInformer.Operator().V1().ClusterCSIDrivers()
-
 	operator := NewVSphereProblemDetectorController(
 		operatorClient,
 		kubeClient,
 		kubeInformers,
 		configInformers.Config().V1().Infrastructures(),
 		controllerConfig.EventRecorder,
-		clusterCSIDriverInformer,
 	)
 
 	logLevelController := loglevel.NewClusterOperatorLoggingController(operatorClient, controllerConfig.EventRecorder)
@@ -69,7 +64,6 @@ func RunOperator(ctx context.Context, controllerConfig *controllercmd.Controller
 		csiConfigInformers,
 		kubeInformers,
 		configInformers,
-		operatorInformer,
 	} {
 		informer.Start(ctx.Done())
 	}


### PR DESCRIPTION

Reverts #166 ; tracked by [TRT-1758](https://issues.redhat.com//browse/TRT-1758)

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

Permafailing vsphere techpreview jobs with: events should not repeat pathologically for ns/openshift-cluster-storage-operator

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of these jobs to confirm the fix has corrected the problem:

```
/payload-job periodic-ci-openshift-release-master-nightly-4.17-e2e-vsphere-ovn-techpreview-serial
```

CC: @mpatlasov

<div align="right">
PR created by <a href="https://github.com/stbenjam/revertomatic">Revertomatic<sup>:tm:</sup></a>
</div>
