### PR TITLE
STOR-1767: Silence vsphere-problem-detector if State is Removed

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/openshift/vsphere-problem-detector/pkg/log"
 	"github.com/openshift/vsphere-problem-detector/pkg/util"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
@@ -131,7 +132,7 @@ func (c *vSphereCache) getDatastoresLocked(ctx context.Context, dcName string) (
 	finder.SetDatacenter(cdc.dc)
 	datastores, err := finder.DatastoreList(tctx, "*")
 	if err != nil {
-		klog.Errorf("failed to get all the datastores. err: %+v", err)
+		log.Logf("failed to get all the datastores. err: %+v", err)
 		return nil, err
 	}
 
@@ -145,7 +146,7 @@ func (c *vSphereCache) getDatastoresLocked(ctx context.Context, dcName string) (
 	properties := []string{DatastoreInfoProperty, SummaryProperty, "customValue"}
 	err = pc.Retrieve(tctx, dsList, properties, &dsMoList)
 	if err != nil {
-		klog.Errorf("failed to get Datastore managed objects from datastore objects."+
+		log.Logf("failed to get Datastore managed objects from datastore objects."+
 			" dsObjList: %+v, properties: %+v, err: %v", dsList, properties, err)
 		return nil, err
 	}
@@ -283,7 +284,7 @@ func (c *vSphereCache) GetStoragePods(ctx context.Context) ([]mo.StoragePod, err
 	defer cancel()
 	v, err := m.CreateContainerView(tctx, c.vmClient.ServiceContent.RootFolder, kind, true)
 	if err != nil {
-		klog.Errorf("error listing datastore cluster: %+v", err)
+		log.Logf("error listing datastore cluster: %+v", err)
 		// Don't alert on missing permissions
 		return nil, nil
 	}
@@ -296,7 +297,7 @@ func (c *vSphereCache) GetStoragePods(ctx context.Context) ([]mo.StoragePod, err
 	defer cancel()
 	err = v.Retrieve(tctx, kind, []string{SummaryProperty, "childEntity"}, &content)
 	if err != nil {
-		klog.Errorf("error retrieving datastore cluster properties: %+v", err)
+		log.Logf("error retrieving datastore cluster properties: %+v", err)
 		// it is possible that we do not actually have permission to fetch datastore clusters
 		// in which case rather than throwing an error - we will silently return nil, so as
 		// we don't trigger unnecessary alerts.

--- a/pkg/check/datastore.go
+++ b/pkg/check/datastore.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/klog/v2"
 
 	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/vsphere-problem-detector/pkg/log"
 	"github.com/openshift/vsphere-problem-detector/pkg/util"
 )
 
@@ -359,7 +360,7 @@ func checkForDatastoreCluster(ctx *CheckContext, dsMo mo.Datastore, dataStoreNam
 			if err != nil {
 				// we may not have permissions to fetch unrelated datastores in OCP
 				// and hence we are going to ignore the error.
-				klog.Errorf("fetching datastore %s failed: %v", child.String(), err)
+				log.Logf("fetching datastore %s failed: %v", child.String(), err)
 				continue
 			}
 			if tDS.Summary.Url == dsMo.Summary.Url {

--- a/pkg/check/permissions.go
+++ b/pkg/check/permissions.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/openshift/vsphere-problem-detector/pkg/log"
 	"github.com/pkg/errors"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/vim25/types"
-	"k8s.io/klog/v2"
 )
 
 const root = "/..."
@@ -149,7 +149,7 @@ func comparePrivileges(ctx context.Context, username string, mo types.ManagedObj
 func checkDatacenterPrivileges(ctx *CheckContext, dataCenterName string) error {
 	matchingDC, err := getDatacenter(ctx, dataCenterName)
 	if err != nil {
-		klog.Errorf("error getting datacenter %s: %v", dataCenterName, err)
+		log.Logf("error getting datacenter %s: %v", dataCenterName, err)
 		return err
 	}
 	if err := comparePrivileges(ctx.Context, ctx.Username, matchingDC.Reference(), ctx.AuthManager, permissions[permissionDatacenter]); err != nil {
@@ -162,7 +162,7 @@ func checkFolderPrivileges(ctx *CheckContext, folderPath string, group permissio
 	finder := find.NewFinder(ctx.VMClient)
 	folder, err := getFolderReference(ctx.Context, folderPath, finder)
 	if err != nil {
-		klog.Errorf("error getting folder %s: %v", folderPath, err)
+		log.Logf("error getting folder %s: %v", folderPath, err)
 		return err
 	}
 	if err := comparePrivileges(ctx.Context, ctx.Username, folder.Reference(), ctx.AuthManager, permissions[group]); err != nil {

--- a/pkg/check/util.go
+++ b/pkg/check/util.go
@@ -8,6 +8,7 @@ import (
 
 	ocpv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/vsphere-problem-detector/pkg/cache"
+	"github.com/openshift/vsphere-problem-detector/pkg/log"
 	"github.com/openshift/vsphere-problem-detector/pkg/util"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
@@ -34,7 +35,7 @@ func getDatastoreByURL(ctx *CheckContext, dsURL string) (dsMo mo.Datastore, dcNa
 			if err == cache.ErrDatastoreNotFound {
 				continue
 			}
-			klog.Errorf("error fetching datastoreURL %s from datacenter %s", dsURL, fd.Topology.Datacenter)
+			log.Logf("error fetching datastoreURL %s from datacenter %s", dsURL, fd.Topology.Datacenter)
 			return
 		}
 		if dsMo.Info.GetDatastoreInfo().Url == dsURL {
@@ -121,7 +122,7 @@ func getClusterComputeResource(ctx *CheckContext, computeCluster string, datacen
 	finder.SetDatacenter(datacenter)
 	computeClusterMo, err := finder.ClusterComputeResource(tctx, computeCluster)
 	if err != nil {
-		klog.Errorf("Unable to get cluster ComputeResource: %s", err)
+		log.Logf("Unable to get cluster ComputeResource: %s", err)
 	}
 	return computeClusterMo, err
 }

--- a/pkg/check/zones.go
+++ b/pkg/check/zones.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/klog/v2"
 
 	v1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/vsphere-problem-detector/pkg/log"
 )
 
 type validationContext struct {
@@ -128,7 +129,7 @@ func CheckZoneTags(ctx *CheckContext) error {
 	klog.V(4).Info("Getting infrastructure configuration.")
 	inf, err := ctx.KubeClient.GetInfrastructure(ctx.Context)
 	if err != nil {
-		klog.Errorf("Error getting infrastructure: %v", err)
+		log.Logf("Error getting infrastructure: %v", err)
 		return err
 	}
 

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,17 @@
+package log
+
+import (
+	"k8s.io/klog/v2"
+)
+
+var (
+	Silenced = false
+)
+
+func Logf(format string, args ...interface{}) {
+	if Silenced {
+		klog.Infof(format, args...)
+	} else {
+		klog.Errorf(format, args...)
+	}
+}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -306,7 +306,9 @@ func (c *vSphereProblemDetectorController) runChecks(ctx context.Context, cluste
 	klog.V(4).Infof("All checks complete")
 
 	results, checkError := resultCollector.Collect()
-	c.reportResults(results)
+	if !silenced {
+		c.reportResults(results)
+	}
 	var nextDelay time.Duration
 	if checkError != nil && !silenced {
 		// Use exponential backoff

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -255,7 +255,7 @@ func TestSyncChecks(t *testing.T) {
 				vsphereProblemOperator.nextCheck = time.Now().Add(10 * time.Second)
 			}
 
-			delay, lastCheckResult, checksPerformed := vsphereProblemOperator.runSyncChecks(context.TODO(), info, false)
+			delay, lastCheckResult, checksPerformed := vsphereProblemOperator.runSyncChecks(context.TODO(), info)
 			if tc.expectedCheckPerfom != checksPerformed {
 				t.Fatalf("for checks performed expected %v got %v", tc.expectedCheckPerfom, checksPerformed)
 			}

--- a/pkg/operator/vsphere_check.go
+++ b/pkg/operator/vsphere_check.go
@@ -13,6 +13,7 @@ import (
 	ocpv1 "github.com/openshift/api/config/v1"
 	"github.com/openshift/vsphere-problem-detector/pkg/cache"
 	"github.com/openshift/vsphere-problem-detector/pkg/check"
+	"github.com/openshift/vsphere-problem-detector/pkg/log"
 	"github.com/openshift/vsphere-problem-detector/pkg/util"
 	"github.com/openshift/vsphere-problem-detector/pkg/version"
 	"github.com/vmware/govmomi"
@@ -53,7 +54,7 @@ func (v *vSphereChecker) runChecks(ctx context.Context, clusterInfo *util.Cluste
 
 	defer func() {
 		if err := checkContext.GovmomiClient.Logout(ctx); err != nil {
-			klog.Errorf("Failed to logout: %v", err)
+			log.Logf("Failed to logout: %v", err)
 		}
 	}()
 
@@ -88,7 +89,7 @@ func (v *vSphereChecker) runChecks(ctx context.Context, clusterInfo *util.Cluste
 
 	klog.V(4).Infof("Waiting for all checks")
 	if err := checkRunner.Wait(ctx); err != nil {
-		klog.Errorf("error waiting for metrics checks to finish: %v", err)
+		log.Logf("error waiting for metrics checks to finish: %v", err)
 		v.controller.metricsCollector.FinishedAllChecks()
 		return resultCollector, err
 	}


### PR DESCRIPTION
vsphere-problem-detector must not emit any events if State is Removed in ClusterCSIDriver. Also, it must use `klog.Infof()` instead of `klog.Errorf()` in this case.