### PR TITLE
OCPBUGS-53386: fix reconciliation failed of obj.Name is empty

### DIFF
--- a/pkg/operator/operatorclient_test.go
+++ b/pkg/operator/operatorclient_test.go
@@ -1,0 +1,140 @@
+package operator
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	applyoperatorv1 "github.com/openshift/client-go/operator/applyconfigurations/operator/v1"
+	fakeoperatorclient "github.com/openshift/client-go/operator/clientset/versioned/fake"
+	operatorinformers "github.com/openshift/client-go/operator/informers/externalversions"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestApplyOperatorStatus_Success(t *testing.T) {
+	ctx := context.Background()
+	fieldManager := "test-manager"
+	globalConfigName := "cluster"
+
+	// Setup fake existing Storage object
+	now := metav1.NewTime(time.Now())
+	existing := &operatorv1.Storage{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: globalConfigName,
+		},
+		Status: operatorv1.StorageStatus{
+			OperatorStatus: operatorv1.OperatorStatus{
+				Conditions: []operatorv1.OperatorCondition{
+					{
+						Type:               "Available",
+						Status:             operatorv1.ConditionTrue,
+						LastTransitionTime: now,
+					},
+				},
+			},
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = operatorv1.AddToScheme(scheme)
+
+	fakeClient := fakeoperatorclient.NewSimpleClientset(existing)
+	storageClient := fakeClient.OperatorV1()
+	informerFactory := operatorinformers.NewSharedInformerFactory(fakeClient, 0)
+	storageInformer := informerFactory.Operator().V1().Storages().Informer()
+	_ = storageInformer.GetStore().Add(existing)
+
+	operatorClient := OperatorClient{
+		Client:    storageClient,
+		Informers: informerFactory,
+	}
+
+	// Define desired status with a new condition to force an update
+	newCondition := operatorv1.OperatorCondition{
+		Type:   "Degraded",
+		Status: operatorv1.ConditionTrue,
+	}
+
+	desiredStatusConf := &applyoperatorv1.OperatorStatusApplyConfiguration{}
+	desiredStatusConf.WithConditions(
+		&applyoperatorv1.OperatorConditionApplyConfiguration{
+			Type:               &newCondition.Type,
+			Status:             &newCondition.Status,
+			LastTransitionTime: &newCondition.LastTransitionTime,
+			Reason:             &newCondition.Reason,
+			Message:            &newCondition.Message,
+		},
+	)
+
+	err := operatorClient.ApplyOperatorStatus(ctx, fieldManager, desiredStatusConf)
+	if err != nil {
+		t.Fatalf("ApplyOperatorStatus returned error: %v", err)
+	}
+
+	// Verify: Storage should be updated with new condition
+	updated, err := fakeClient.OperatorV1().Storages().Get(ctx, globalConfigName, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get updated storage: %v", err)
+	}
+
+	found := false
+	for _, cond := range updated.Status.Conditions {
+		if cond.Type == "Degraded" && cond.Status == operatorv1.ConditionTrue {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Errorf("expected condition Degraded=True not found in updated status: %+v", updated.Status.Conditions)
+	}
+}
+
+func TestApplyOperatorStatus_NilInput(t *testing.T) {
+	client := OperatorClient{}
+	err := client.ApplyOperatorStatus(context.Background(), "test-manager", nil)
+	if err == nil || err.Error() != "desiredStatusConfiguration must have a value" {
+		t.Errorf("expected error for nil configuration, got: %v", err)
+	}
+}
+
+func TestApplyOperatorStatus_GetError(t *testing.T) {
+	ctx := context.Background()
+
+	// Setup fake client with no existing objects
+	fakeClient := fakeoperatorclient.NewSimpleClientset()
+	storageClient := fakeClient.OperatorV1()
+	informerFactory := operatorinformers.NewSharedInformerFactory(fakeClient, 0)
+
+	operatorClient := OperatorClient{
+		Client:    storageClient,
+		Informers: informerFactory,
+	}
+
+	// Define desired status with a new condition
+	newCondition := operatorv1.OperatorCondition{
+		Type:   "Processing",
+		Status: operatorv1.ConditionTrue,
+	}
+
+	desiredStatusConf := &applyoperatorv1.OperatorStatusApplyConfiguration{}
+	desiredStatusConf.WithConditions(
+		&applyoperatorv1.OperatorConditionApplyConfiguration{
+			Type:               &newCondition.Type,
+			Status:             &newCondition.Status,
+			LastTransitionTime: &newCondition.LastTransitionTime,
+			Reason:             &newCondition.Reason,
+			Message:            &newCondition.Message,
+		},
+	)
+
+	err := operatorClient.ApplyOperatorStatus(ctx, "test-manager", desiredStatusConf)
+
+	// Expect failed when object is not found
+	if err == nil || strings.Contains(err.Error(), "storages\\.operator\\.openshift\\.io \"cluster\" not found") {
+		t.Errorf("expected error for NotFound case, but got: %v", err)
+	}
+}


### PR DESCRIPTION
#### RCA
-  After we bump the depeddencies in https://github.com/openshift/vsphere-problem-detector/pull/177 , it brings an problem that the operator morbidly logged "VSphereProblemDetectorController reconciliation failed: obj.Name must be provided to Apply"

```console
$ oc logs vsphere-problem-detector-operator-f7d744b6c-kzz84|grep 'VSphereProblemDetectorController reconciliation failed: obj.Name must be provided to Apply'
...
E0319 20:34:49.128922       1 base_controller.go:279] "Unhandled Error" err="VSphereProblemDetectorController reconciliation failed: obj.Name must be provided to Apply"
E0319 20:34:49.136715       1 base_controller.go:279] "Unhandled Error" err="VSphereProblemDetectorController reconciliation failed: obj.Name must be provided to Apply"
E0319 20:34:49.154389       1 base_controller.go:279] "Unhandled Error" err="VSphereProblemDetectorController reconciliation failed: obj.Name must be provided to Apply"
E0319 20:34:49.179479       1 base_controller.go:279] "Unhandled Error" err="VSphereProblemDetectorController reconciliation failed: obj.Name must be provided to Apply"
E0319 20:34:49.221206       1 base_controller.go:279] "Unhandled Error" err="VSphereProblemDetectorController reconciliation failed: obj.Name must be provided to Apply"
E0319 20:34:49.303478       1 base_controller.go:279] "Unhandled Error" err="VSphereProblemDetectorController reconciliation failed: obj.Name must be provided to Apply"
E0319 20:34:49.464873       1 base_controller.go:279] "Unhandled Error" err="VSphereProblemDetectorController reconciliation failed: obj.Name must be provided to Apply"
E0319 20:34:49.781316       1 base_controller.go:279] "Unhandled Error" err="VSphereProblemDetectorController reconciliation failed: obj.Name must be provided to Apply"
E0319 20:34:49.786932       1 base_controller.go:279] "Unhandled Error" err="VSphereProblemDetectorController reconciliation failed: obj.Name must be provided to Apply"
E0319 20:34:51.070538       1 base_controller.go:279] "Unhandled Error" err="VSphereProblemDetectorController reconciliation failed: obj.Name must be provided to Apply"
E0319 20:34:53.632356       1 base_controller.go:279] "Unhandled Error" err="VSphereProblemDetectorController reconciliation failed: obj.Name must be provided to Apply"
...
$ oc logs vsphere-problem-detector-operator-f7d744b6c-kzz84|grep 'VSphereProblemDetectorController reconciliation failed: obj.Name must be provided to Apply'|wc -l
    6682

```
[CI logs](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.19-e2e-vsphere-ovn-csi/1902607690383757312/artifacts/e2e-vsphere-ovn-csi/gather-extra/artifacts/pods/openshift-cluster-storage-operator_vsphere-problem-detector-operator-ff97c5c9-r6b48_vsphere-problem-detector-operator.log)

#### Fix solution
- Add the missed `obj.Name`, Kind, Version for the apply configuration, in addition when applyStatus we need ensure the `LastTransitionTime` is not null, otherwise it will be failed of `status.conditions[22].lastTransitionTime: Required value, <nil>: Invalid value: \"null\": some validation rules were not checked because the object was invalid`.

#### Local test record
Manually build the operator image and replace in live cluster check the error logs disappeared.

```console
$ oc logs vsphere-problem-detector-operator-554bc565bc-rvmb7|grep 'VSphereProblemDetectorController reconciliation failed'|wc -l
0

$  oc logs vsphere-problem-detector-operator-554bc565bc-rvmb7|grep -E 'W0320|E0320'
W0320 08:50:15.070190       1 secure_serving.go:69] Use of insecure cipher 'TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256' detected.
W0320 08:50:15.070194       1 secure_serving.go:69] Use of insecure cipher 'TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256' detected.
W0320 08:50:15.070199       1 secure_serving.go:69] Use of insecure cipher 'TLS_RSA_WITH_AES_128_GCM_SHA256' detected.
W0320 08:50:15.070202       1 secure_serving.go:69] Use of insecure cipher 'TLS_RSA_WITH_AES_256_GCM_SHA384' detected.
W0320 08:50:15.070205       1 secure_serving.go:69] Use of insecure cipher 'TLS_RSA_WITH_AES_128_CBC_SHA' detected.
W0320 08:50:15.070208       1 secure_serving.go:69] Use of insecure cipher 'TLS_RSA_WITH_AES_256_CBC_SHA' detected.
```