### PR TITLE
OCPBUGS-56274: add datacenter consistency check

### DIFF
--- a/pkg/check/datacenter_consistency.go
+++ b/pkg/check/datacenter_consistency.go
@@ -1,0 +1,86 @@
+package check
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/klog/v2"
+
+	"github.com/openshift/vsphere-problem-detector/pkg/util"
+)
+
+// CheckDatacenterConsistency validates that every datacenter referenced by a failure domain
+// in the Infrastructure CR is also listed in the cloud provider config (cloud.conf).
+// A mismatch means the CSI driver cannot find VMs in the affected zone.
+func CheckDatacenterConsistency(ctx *CheckContext) error {
+	klog.Info("Checking datacenter consistency between failure domains and cloud provider config.")
+
+	infra, err := ctx.KubeClient.GetInfrastructure(ctx.Context)
+	if err != nil {
+		klog.Errorf("Error getting infrastructure: %v", err)
+		return err
+	}
+
+	if infra.Spec.PlatformSpec.VSphere == nil || len(infra.Spec.PlatformSpec.VSphere.FailureDomains) == 0 {
+		klog.V(2).Info("Skipping datacenter consistency check due to legacy infra config.")
+		return nil
+	}
+
+	var errs []error
+	cfg := ctx.VMConfig.Config
+
+	for _, fd := range infra.Spec.PlatformSpec.VSphere.FailureDomains {
+		vcConfig := cfg.VirtualCenter[fd.Server]
+		if vcConfig == nil {
+			klog.V(4).Infof("vCenter %q not found in cloud provider config for failure domain %q, skipping (handled by CheckInfraConfig)", fd.Server, fd.Name)
+			continue
+		}
+
+		configuredDCs := parseDatacenters(vcConfig.Datacenters)
+		if !containsString(configuredDCs, fd.Topology.Datacenter) {
+			err := fmt.Errorf("Datacenter-Consistency: failure domain %q (infrastructure.config.openshift.io/cluster) "+
+				"requires datacenter %q on vCenter %q, but it is not listed in the cloud provider config "+
+				"(datacenters = %q in vsphere-csi-config-secret, namespace openshift-cluster-csi-drivers). "+
+				"Add %q to the datacenters list in the cloud-provider-config ConfigMap in the %s namespace.",
+				fd.Name, fd.Topology.Datacenter, fd.Server,
+				vcConfig.Datacenters,
+				fd.Topology.Datacenter, util.CloudConfigNamespace)
+			errs = append(errs, err)
+			klog.Warningf("%v", err)
+		}
+	}
+
+	for _, fd := range infra.Spec.PlatformSpec.VSphere.FailureDomains {
+		for _, vc := range infra.Spec.PlatformSpec.VSphere.VCenters {
+			if vc.Server == fd.Server {
+				if !containsString(vc.Datacenters, fd.Topology.Datacenter) {
+					err := fmt.Errorf("Datacenter-Consistency: failure domain %q references datacenter %q "+
+						"on vCenter %q, but it is not listed in the vcenters section of "+
+						"infrastructure.config.openshift.io/cluster (datacenters = %v). "+
+						"Add %q to the datacenters list for vCenter %q in the Infrastructure CR.",
+						fd.Name, fd.Topology.Datacenter, fd.Server,
+						vc.Datacenters, fd.Topology.Datacenter, fd.Server)
+					errs = append(errs, err)
+					klog.Warningf("%v", err)
+				}
+				break
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return join(errs)
+	}
+	return nil
+}
+
+func parseDatacenters(raw string) []string {
+	var result []string
+	for _, dc := range strings.Split(raw, ",") {
+		trimmed := strings.TrimSpace(dc)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}

--- a/pkg/check/datacenter_consistency_test.go
+++ b/pkg/check/datacenter_consistency_test.go
@@ -1,0 +1,158 @@
+package check
+
+import (
+	"testing"
+	"time"
+
+	v1 "github.com/openshift/api/config/v1"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/openshift/vsphere-problem-detector/pkg/testlib"
+	"github.com/openshift/vsphere-problem-detector/pkg/util"
+)
+
+func TestCheckDatacenterConsistency(t *testing.T) {
+	tests := []struct {
+		name           string
+		configFile     string
+		infrastructure *v1.Infrastructure
+		expectErr      string
+	}{
+		{
+			name:           "legacy config (no failure domains)",
+			configFile:     "simple_config.ini",
+			infrastructure: testlib.Infrastructure(),
+		},
+		{
+			name:           "all datacenters present in cloud.conf (ini)",
+			configFile:     "simple_config.ini",
+			infrastructure: testlib.InfrastructureWithFailureDomain(),
+		},
+		{
+			name:       "all datacenters present in cloud.conf (yaml)",
+			configFile: "simple_config.yaml",
+			infrastructure: func() *v1.Infrastructure {
+				inf := testlib.InfrastructureWithMultiVCenters()
+				inf.Spec.PlatformSpec.VSphere.FailureDomains[0].Topology.Datacenter = "cidatacenter"
+				inf.Spec.PlatformSpec.VSphere.FailureDomains[1].Topology.Datacenter = "IBMCloud"
+				inf.Spec.PlatformSpec.VSphere.VCenters[0].Datacenters = []string{"cidatacenter"}
+				inf.Spec.PlatformSpec.VSphere.VCenters[1].Datacenters = []string{"IBMCloud"}
+				return inf
+			}(),
+		},
+		{
+			name:       "one datacenter missing from cloud.conf (ini)",
+			configFile: "simple_config.ini",
+			infrastructure: func() *v1.Infrastructure {
+				inf := testlib.InfrastructureWithFailureDomain()
+				inf.Spec.PlatformSpec.VSphere.FailureDomains = append(
+					inf.Spec.PlatformSpec.VSphere.FailureDomains,
+					v1.VSpherePlatformFailureDomainSpec{
+						Name:   "us-west-1",
+						Server: "dc0",
+						Topology: v1.VSpherePlatformTopology{
+							Datacenter: "DC-MISSING",
+						},
+					},
+				)
+				return inf
+			}(),
+			expectErr: `Datacenter-Consistency: failure domain "us-west-1".*requires datacenter "DC-MISSING" on vCenter "dc0".*cloud-provider-config ConfigMap in the openshift-config namespace`,
+		},
+		{
+			name:       "one datacenter missing from cloud.conf (yaml)",
+			configFile: "simple_config.yaml",
+			infrastructure: func() *v1.Infrastructure {
+				inf := testlib.InfrastructureWithMultiVCenters()
+				inf.Spec.PlatformSpec.VSphere.FailureDomains[1].Topology.Datacenter = "DC-MISSING"
+				return inf
+			}(),
+			expectErr: `Datacenter-Consistency: failure domain "failure-domain-2".*requires datacenter "DC-MISSING" on vCenter "vcenter2.test.openshift.com"`,
+		},
+		{
+			name:       "multiple datacenters missing from cloud.conf",
+			configFile: "simple_config.yaml",
+			infrastructure: func() *v1.Infrastructure {
+				inf := testlib.InfrastructureWithMultiVCenters()
+				inf.Spec.PlatformSpec.VSphere.FailureDomains[0].Topology.Datacenter = "MISSING-1"
+				inf.Spec.PlatformSpec.VSphere.FailureDomains[1].Topology.Datacenter = "MISSING-2"
+				return inf
+			}(),
+			expectErr: `(?s)MISSING-1.*MISSING-2`,
+		},
+		{
+			name:       "vCenter not in cloud.conf is skipped (handled by CheckInfraConfig)",
+			configFile: "simple_config.ini",
+			infrastructure: func() *v1.Infrastructure {
+				inf := testlib.InfrastructureWithFailureDomain()
+				inf.Spec.PlatformSpec.VSphere.FailureDomains[0].Server = "unknown-vcenter"
+				return inf
+			}(),
+		},
+		{
+			name:       "datacenter missing from vCenters section in infra CR",
+			configFile: "simple_config.ini",
+			infrastructure: func() *v1.Infrastructure {
+				inf := testlib.InfrastructureWithFailureDomain()
+				inf.Spec.PlatformSpec.VSphere.VCenters[0].Datacenters = []string{"OTHER-DC"}
+				return inf
+			}(),
+			expectErr: `Datacenter-Consistency: failure domain "dc0".*datacenter "DC0".*not listed in the vcenters section`,
+		},
+		{
+			name:       "datacenter missing from vCenters section in multi-vCenter infra CR",
+			configFile: "simple_config.yaml",
+			infrastructure: func() *v1.Infrastructure {
+				inf := testlib.InfrastructureWithMultiVCenters()
+				inf.Spec.PlatformSpec.VSphere.FailureDomains[0].Topology.Datacenter = "cidatacenter"
+				inf.Spec.PlatformSpec.VSphere.FailureDomains[1].Topology.Datacenter = "IBMCloud"
+				inf.Spec.PlatformSpec.VSphere.VCenters[0].Datacenters = []string{"cidatacenter"}
+				inf.Spec.PlatformSpec.VSphere.VCenters[1].Datacenters = []string{"OTHER-DC"}
+				return inf
+			}(),
+			expectErr: `Datacenter-Consistency: failure domain "failure-domain-2".*datacenter "IBMCloud".*not listed in the vcenters section`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			kubeClient := &testlib.FakeKubeClient{
+				Infrastructure: test.infrastructure,
+			}
+			ctx, cleanup, err := SetupSimulatorWithConfig(kubeClient, testlib.DefaultModel, test.configFile)
+			if err != nil {
+				t.Fatalf("setupSimulator failed: %s", err)
+			}
+			defer cleanup()
+
+			oldTimeout := *util.Timeout
+			*util.Timeout = time.Second
+			t.Cleanup(func() {
+				*util.Timeout = oldTimeout
+			})
+			err = CheckDatacenterConsistency(ctx)
+
+			if test.expectErr == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Regexp(t, test.expectErr, err)
+			}
+		})
+	}
+}
+
+func TestParseDatacenters(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected []string
+	}{
+		{"DC0", []string{"DC0"}},
+		{"DC0,DC1", []string{"DC0", "DC1"}},
+		{" DC0 , DC1 ", []string{"DC0", "DC1"}},
+		{"", nil},
+	}
+	for _, test := range tests {
+		result := parseDatacenters(test.input)
+		assert.Equal(t, test.expected, result)
+	}
+}

--- a/pkg/check/interface.go
+++ b/pkg/check/interface.go
@@ -20,16 +20,17 @@ import (
 var (
 	// DefaultClusterChecks is the list of all checks.
 	DefaultClusterChecks map[string]ClusterCheck = map[string]ClusterCheck{
-		"CheckTaskPermissions":    CheckTaskPermissions,
-		"ClusterInfo":             CollectClusterInfo,
-		"CheckFolderPermissions":  CheckFolderPermissions,
-		"CheckDefaultDatastore":   CheckDefaultDatastore,
-		"CheckStorageClasses":     CheckStorageClasses,
-		"CountVolumeTypes":        CountPVTypes,
-		"CheckAccountPermissions": CheckAccountPermissions,
-		"CheckZoneTags":           CheckZoneTags,
-		"CheckHostGroups":         CheckHostGroups,
-		"CheckInfraConfig":        CheckInfraConfig,
+		"CheckTaskPermissions":       CheckTaskPermissions,
+		"ClusterInfo":                CollectClusterInfo,
+		"CheckFolderPermissions":     CheckFolderPermissions,
+		"CheckDefaultDatastore":      CheckDefaultDatastore,
+		"CheckStorageClasses":        CheckStorageClasses,
+		"CountVolumeTypes":           CountPVTypes,
+		"CheckAccountPermissions":    CheckAccountPermissions,
+		"CheckZoneTags":              CheckZoneTags,
+		"CheckHostGroups":            CheckHostGroups,
+		"CheckInfraConfig":           CheckInfraConfig,
+		"CheckDatacenterConsistency": CheckDatacenterConsistency,
 	}
 	DefaultNodeChecks []NodeCheck = []NodeCheck{
 		&CheckNodeDiskUUID{},


### PR DESCRIPTION
When using zonal deployments of vSphere with OpenShift, if a datacenter referenced by a failure domain in the Infrastructure CR (`infrastructure.config.openshift.io/cluster`) is missing from the cloud provider config (`cloud-provider-config` ConfigMap in `openshift-config`), the CSI driver silently fails to find VMs in that zone, causing the cluster to degrade. The vSphere Problem Detector (VPD) had no check to detect this misconfiguration. This fix adds a new cluster-level check, `CheckDatacenterConsistency`, that compares each failure domain's required datacenter against the datacenters listed in the parsed `cloud.conf` (`ctx.VMConfig.Config.VirtualCenter[server].Datacenters`). When a datacenter is absent, VPD emits a WARNING naming the missing datacenter, the affected failure domain, and instructs the administrator to update the `cloud-provider-config` ConfigMap in the `openshift-config` namespace.

## Cluster Setup

Two failure domains configured:
- `us-east-1` → datacenter `nested-devqedatacenter-1`
- `us-west-1` → datacenter `nested-devqedatacenter-2`

Both on vCenter `232-15-184-10.in-addr.arpa`.

## Simulating the Bug

The datacenter `nested-devqedatacenter-2` was removed from `cloud-provider-config`:

```bash
# Edit cloud-provider-config to remove nested-devqedatacenter-2
oc -n openshift-config edit configmap cloud-provider-config
# Changed: datacenters = nested-devqedatacenter-1,nested-devqedatacenter-2
# To:      datacenters = nested-devqedatacenter-1

# Verified propagation to vsphere-csi-config-secret:
oc -n openshift-cluster-csi-drivers get secret/vsphere-csi-config-secret \
  -o jsonpath='{.data.cloud\.conf}' | base64 -d
# Output confirmed: datacenters = nested-devqedatacenter-1
```

## Unpatched Behaviour (openshift/main)

```bash
export KUBECONFIG=/Users/MAC/openshift/clusters/vsphere/cluster-01/auth/kubeconfig
git checkout openshift/main && make
./vsphere-problem-detector start -v 5 \
  --kubeconfig=$KUBECONFIG \
  --namespace=openshift-cluster-storage-operator
```

Relevant log lines:

```
I0219 16:17:18.909862   17481 infra_config.go:15] Checking infrastructure and cloud provider config for consistency.
I0219 16:17:18.909897   17481 vsphere_check.go:302] CheckInfraConfig passed
I0219 16:17:24.169406   17481 vsphere_check.go:109] Finished running all vSphere specific checks in the cluster
I0219 16:17:24.307163   17481 event.go:377] ... type: 'Normal' reason: 'SucceededVSphereCheckInfraConfig' Check succeeded
```

**No warning or error about the missing datacenter `nested-devqedatacenter-2`.**

## Patched Behaviour (OCPBUGS-56274)

```bash
git checkout OCPBUGS-56274 && make
./vsphere-problem-detector start -v 5 \
  --kubeconfig=$KUBECONFIG \
  --namespace=openshift-cluster-storage-operator
```

Relevant log lines:

```
I0219 16:23:24.680681   32885 datacenter_consistency.go:16] Checking datacenter consistency between failure domains and cloud provider config.
W0219 16:23:24.680821   32885 datacenter_consistency.go:50] Datacenter-Consistency: failure domain "us-west-1" (infrastructure.config.openshift.io/cluster) requires datacenter "nested-devqedatacenter-2" on vCenter "232-15-184-10.in-addr.arpa", but it is not listed in the cloud provider config (datacenters = "nested-devqedatacenter-1" in vsphere-csi-config-secret, namespace openshift-cluster-csi-drivers). Add "nested-devqedatacenter-2" to the datacenters list in the cloud-provider-config ConfigMap in the openshift-config namespace.
I0219 16:23:24.680835   32885 vsphere_check.go:299] CheckDatacenterConsistency failed: Datacenter-Consistency: failure domain "us-west-1" ...
I0219 16:23:30.292865   32885 event.go:377] ... type: 'Warning' reason: 'FailedVSphereCheckDatacenterConsistency' Datacenter-Consistency: failure domain "us-west-1" (infrastructure.config.openshift.io/cluster) requires datacenter "nested-devqedatacenter-2" on vCenter "232-15-184-10.in-addr.arpa" ...
```

**WARNING emitted, explicitly naming `nested-devqedatacenter-2` as missing, with remediation instructions.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a validation that ensures vSphere failure domains reference datacenters present in the configured vCenter settings; emits warnings and returns an error when mismatches are found.

* **Tests**
  * Added comprehensive tests covering legacy behavior, single/multi-vCenter setups, missing datacenters, and datacenter-list parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->