### PR TITLE
OCPBUGS-79057: Fixed compute cluster permission logic for single fd with read-only custom resourcepool

### DIFF
--- a/pkg/check/node_cluster_permissions.go
+++ b/pkg/check/node_cluster_permissions.go
@@ -66,14 +66,34 @@ func (c *CheckComputeClusterPermissions) CheckNode(ctx *CheckContext, node *v1.N
 		klog.Info("Detected legacy config with custom ResourcePool")
 		readOnly = true
 	} else if ctx.PlatformSpec != nil {
-		region := node.Labels["topology.kubernetes.io/region"]
-		zone := node.Labels["topology.kubernetes.io/zone"]
+		// Read region/zone labels, falling back to beta labels for older clusters
+		region := node.Labels[v1.LabelTopologyRegion]
+		if len(region) == 0 {
+			region = node.Labels[v1.LabelFailureDomainBetaRegion]
+		}
+		zone := node.Labels[v1.LabelTopologyZone]
+		if len(zone) == 0 {
+			zone = node.Labels[v1.LabelFailureDomainBetaZone]
+		}
 
-		for _, fd := range ctx.PlatformSpec.FailureDomains {
+		// Special case: if there's only one failure domain with a custom ResourcePool,
+		// assume it applies to all nodes (common in single-zone installs where region/zone labels may be fake)
+		if len(ctx.PlatformSpec.FailureDomains) == 1 {
+			fd := ctx.PlatformSpec.FailureDomains[0]
 			rp := fd.Topology.ResourcePool
-			if fd.Region == region && fd.Zone == zone && rp != "" && !strings.HasSuffix(rp, "/Resources") {
-				klog.Info("Detected failure domain with custom ResourcePool")
+			if rp != "" && !strings.HasSuffix(rp, "/Resources") {
+				klog.Info("Detected single failure domain with custom ResourcePool")
 				readOnly = true
+			}
+		} else {
+			// Multiple failure domains: match by region/zone labels
+			for _, fd := range ctx.PlatformSpec.FailureDomains {
+				rp := fd.Topology.ResourcePool
+				if fd.Region == region && fd.Zone == zone && rp != "" && !strings.HasSuffix(rp, "/Resources") {
+					klog.Info("Detected failure domain with custom ResourcePool")
+					readOnly = true
+					break
+				}
 			}
 		}
 	}

--- a/pkg/check/node_cluster_permissions_test.go
+++ b/pkg/check/node_cluster_permissions_test.go
@@ -170,7 +170,8 @@ func TestCheckComputeClusterPermissions_Infrastructure_NotReadOnly_DefaultRP(t *
 	if ctx.VMConfig.LegacyConfig != nil {
 		ctx.VMConfig.LegacyConfig.Workspace.ResourcePoolPath = ""
 	}
-	// Force missing cluster permissions so the non-read-only path surfaces an error
+	// Set missing cluster permissions to verify non-read-only path would check them.
+	// Note: In the simulator, getComputeCluster fails early so permission check is never reached.
 	setMissingClusterPermissionsAuthManager(t, ctx)
 
 	// Get VM for node
@@ -186,6 +187,332 @@ func TestCheckComputeClusterPermissions_Infrastructure_NotReadOnly_DefaultRP(t *
 	// Act
 	err = check.CheckNode(ctx, node, vm)
 
-	// Assert: expect no error when using custom ResourcePool
+	// Assert: Default ResourcePool doesn't trigger read-only, so would check permissions in production.
+	// In simulator, getComputeCluster fails so test returns nil without reaching permission check.
+	assert.NoError(t, err)
+}
+
+func TestCheckComputeClusterPermissions_SingleFailureDomain_ReadOnly_WithCustomRP(t *testing.T) {
+	// Stage
+	check := &CheckComputeClusterPermissions{}
+	if err := check.StartCheck(); err != nil {
+		t.Fatalf("StartCheck failed: %v", err)
+	}
+
+	// Node WITHOUT region/zone labels (simulating single-zone install with fake/missing labels)
+	node := testlib.Node("DC0_H0_VM0")
+
+	infra := testlib.InfrastructureWithFailureDomain(func(inf *ocpv1.Infrastructure) {
+		// Set a custom ResourcePool path (not ending with /Resources) to trigger read_only
+		inf.Spec.PlatformSpec.VSphere.FailureDomains[0].Topology.ResourcePool = "/DC0/host/DC0_C0/Resources/test-resourcepool"
+	})
+
+	kubeClient := &testlib.FakeKubeClient{
+		Infrastructure: infra,
+		Nodes:          []*k8sv1.Node{node},
+	}
+	ctx, cleanup, err := SetupSimulator(kubeClient, testlib.DefaultModel)
+	if err != nil {
+		t.Fatalf("setupSimulator failed: %s", err)
+	}
+	defer cleanup()
+
+	// Ensure legacy path does not interfere
+	if ctx.VMConfig.LegacyConfig != nil {
+		ctx.VMConfig.LegacyConfig.Workspace.ResourcePoolPath = ""
+	}
+	// Ensure cluster permissions would be missing if checked (to prove read_only skips)
+	setMissingClusterPermissionsAuthManager(t, ctx)
+
+	// Get VM for node
+	vCenter, err := GetVCenter(ctx, node)
+	if err != nil {
+		t.Fatalf("error getting vCenter for node %s: %s", node.Name, err)
+	}
+	vm, err := testlib.GetVM(vCenter.VMClient, node)
+	if err != nil {
+		t.Fatalf("error getting vm for node %s: %s", node.Name, err)
+	}
+
+	// Act
+	err = check.CheckNode(ctx, node, vm)
+
+	// Assert: should NOT error due to single failure domain with custom ResourcePool (read-only)
+	assert.NoError(t, err)
+}
+
+func TestCheckComputeClusterPermissions_SingleFailureDomain_ReadOnly_WithFakeLabels(t *testing.T) {
+	// Stage
+	check := &CheckComputeClusterPermissions{}
+	if err := check.StartCheck(); err != nil {
+		t.Fatalf("StartCheck failed: %v", err)
+	}
+
+	// Node with "fake" region/zone labels that DON'T match the failure domain
+	// This simulates installer-generated fake values
+	node := testlib.Node("DC0_H0_VM0", func(n *k8sv1.Node) {
+		if n.Labels == nil {
+			n.Labels = map[string]string{}
+		}
+		n.Labels["topology.kubernetes.io/region"] = "region1"
+		n.Labels["topology.kubernetes.io/zone"] = "zone1"
+	})
+
+	infra := testlib.InfrastructureWithFailureDomain(func(inf *ocpv1.Infrastructure) {
+		// Failure domain has different region/zone than node labels
+		inf.Spec.PlatformSpec.VSphere.FailureDomains[0].Region = "east"
+		inf.Spec.PlatformSpec.VSphere.FailureDomains[0].Zone = "east-1a"
+		// Set a custom ResourcePool path
+		inf.Spec.PlatformSpec.VSphere.FailureDomains[0].Topology.ResourcePool = "/DC0/host/DC0_C0/Resources/custom-pool"
+	})
+
+	kubeClient := &testlib.FakeKubeClient{
+		Infrastructure: infra,
+		Nodes:          []*k8sv1.Node{node},
+	}
+	ctx, cleanup, err := SetupSimulator(kubeClient, testlib.DefaultModel)
+	if err != nil {
+		t.Fatalf("setupSimulator failed: %s", err)
+	}
+	defer cleanup()
+
+	// Ensure legacy path does not interfere
+	if ctx.VMConfig.LegacyConfig != nil {
+		ctx.VMConfig.LegacyConfig.Workspace.ResourcePoolPath = ""
+	}
+	// Ensure cluster permissions would be missing if checked
+	setMissingClusterPermissionsAuthManager(t, ctx)
+
+	// Get VM for node
+	vCenter, err := GetVCenter(ctx, node)
+	if err != nil {
+		t.Fatalf("error getting vCenter for node %s: %s", node.Name, err)
+	}
+	vm, err := testlib.GetVM(vCenter.VMClient, node)
+	if err != nil {
+		t.Fatalf("error getting vm for node %s: %s", node.Name, err)
+	}
+
+	// Act
+	err = check.CheckNode(ctx, node, vm)
+
+	// Assert: should NOT error - single failure domain logic should apply regardless of label mismatch
+	assert.NoError(t, err)
+}
+
+func TestCheckComputeClusterPermissions_SingleFailureDomain_NotReadOnly_DefaultRP(t *testing.T) {
+	// Stage
+	check := &CheckComputeClusterPermissions{}
+	if err := check.StartCheck(); err != nil {
+		t.Fatalf("StartCheck failed: %v", err)
+	}
+
+	// Node without region/zone labels
+	node := testlib.Node("DC0_H0_VM0")
+
+	infra := testlib.InfrastructureWithFailureDomain(func(inf *ocpv1.Infrastructure) {
+		// Set ResourcePool to default cluster Resources (ends with /Resources) -> not read-only
+		inf.Spec.PlatformSpec.VSphere.FailureDomains[0].Topology.ResourcePool = "/DC0/host/DC0_C0/Resources"
+	})
+
+	kubeClient := &testlib.FakeKubeClient{
+		Infrastructure: infra,
+		Nodes:          []*k8sv1.Node{node},
+	}
+	ctx, cleanup, err := SetupSimulator(kubeClient, testlib.DefaultModel)
+	if err != nil {
+		t.Fatalf("setupSimulator failed: %s", err)
+	}
+	defer cleanup()
+
+	// Ensure legacy path does not interfere
+	if ctx.VMConfig.LegacyConfig != nil {
+		ctx.VMConfig.LegacyConfig.Workspace.ResourcePoolPath = ""
+	}
+	// Set missing cluster permissions to verify non-read-only path would check them.
+	// Note: In the simulator, getComputeCluster fails early so permission check is never reached.
+	setMissingClusterPermissionsAuthManager(t, ctx)
+
+	// Get VM for node
+	vCenter, err := GetVCenter(ctx, node)
+	if err != nil {
+		t.Fatalf("error getting vCenter for node %s: %s", node.Name, err)
+	}
+	vm, err := testlib.GetVM(vCenter.VMClient, node)
+	if err != nil {
+		t.Fatalf("error getting vm for node %s: %s", node.Name, err)
+	}
+
+	// Act
+	err = check.CheckNode(ctx, node, vm)
+
+	// Assert: Default ResourcePool doesn't trigger read-only, so would check permissions in production.
+	// In simulator, getComputeCluster fails so test returns nil without reaching permission check.
+	assert.NoError(t, err)
+}
+
+func TestCheckComputeClusterPermissions_MultipleFailureDomains_RequiresLabelMatch(t *testing.T) {
+	// Stage
+	check := &CheckComputeClusterPermissions{}
+	if err := check.StartCheck(); err != nil {
+		t.Fatalf("StartCheck failed: %v", err)
+	}
+
+	// Node without region/zone labels
+	node := testlib.Node("DC0_H0_VM0")
+
+	infra := testlib.InfrastructureWithMultipleFailureDomain(func(inf *ocpv1.Infrastructure) {
+		// Set custom ResourcePool on first failure domain
+		inf.Spec.PlatformSpec.VSphere.FailureDomains[0].Topology.ResourcePool = "/DC0/host/DC0_C0/Resources/custom-pool"
+		// Set custom ResourcePool on second failure domain
+		inf.Spec.PlatformSpec.VSphere.FailureDomains[1].Topology.ResourcePool = "/DC1/host/DC0_C1/Resources/another-pool"
+	})
+
+	kubeClient := &testlib.FakeKubeClient{
+		Infrastructure: infra,
+		Nodes:          []*k8sv1.Node{node},
+	}
+	ctx, cleanup, err := SetupSimulator(kubeClient, testlib.DefaultModel)
+	if err != nil {
+		t.Fatalf("setupSimulator failed: %s", err)
+	}
+	defer cleanup()
+
+	// Ensure legacy path does not interfere
+	if ctx.VMConfig.LegacyConfig != nil {
+		ctx.VMConfig.LegacyConfig.Workspace.ResourcePoolPath = ""
+	}
+	// Set missing cluster permissions to verify non-read-only path would check them.
+	// Note: In the simulator, getComputeCluster fails early so permission check is never reached.
+	setMissingClusterPermissionsAuthManager(t, ctx)
+
+	// Get VM for node
+	vCenter, err := GetVCenter(ctx, node)
+	if err != nil {
+		t.Fatalf("error getting vCenter for node %s: %s", node.Name, err)
+	}
+	vm, err := testlib.GetVM(vCenter.VMClient, node)
+	if err != nil {
+		t.Fatalf("error getting vm for node %s: %s", node.Name, err)
+	}
+
+	// Act
+	err = check.CheckNode(ctx, node, vm)
+
+	// Assert: With multiple failure domains, label matching is required.
+	// Node has no labels, so no failure domain matches, and read-only isn't triggered.
+	// In simulator, getComputeCluster fails so test returns nil without reaching permission check.
+	assert.NoError(t, err)
+}
+
+func TestCheckComputeClusterPermissions_Infrastructure_ReadOnly_WithBetaLabels(t *testing.T) {
+	// Stage
+	check := &CheckComputeClusterPermissions{}
+	if err := check.StartCheck(); err != nil {
+		t.Fatalf("StartCheck failed: %v", err)
+	}
+
+	// Node with BETA region/zone labels (older clusters)
+	node := testlib.Node("DC0_H0_VM0", func(n *k8sv1.Node) {
+		if n.Labels == nil {
+			n.Labels = map[string]string{}
+		}
+		n.Labels[k8sv1.LabelFailureDomainBetaRegion] = "east"
+		n.Labels[k8sv1.LabelFailureDomainBetaZone] = "east-1a"
+	})
+
+	infra := testlib.InfrastructureWithFailureDomain(func(inf *ocpv1.Infrastructure) {
+		// Set a custom ResourcePool path (not ending with /Resources) to trigger read_only
+		inf.Spec.PlatformSpec.VSphere.FailureDomains[0].Topology.ResourcePool = "/DC0/host/DC0_C0/Resources/test-resourcepool"
+	})
+
+	kubeClient := &testlib.FakeKubeClient{
+		Infrastructure: infra,
+		Nodes:          []*k8sv1.Node{node},
+	}
+	ctx, cleanup, err := SetupSimulator(kubeClient, testlib.DefaultModel)
+	if err != nil {
+		t.Fatalf("setupSimulator failed: %s", err)
+	}
+	defer cleanup()
+
+	// Ensure legacy path does not interfere
+	if ctx.VMConfig.LegacyConfig != nil {
+		ctx.VMConfig.LegacyConfig.Workspace.ResourcePoolPath = ""
+	}
+	// Ensure cluster permissions would be missing if checked (to prove read_only skips)
+	setMissingClusterPermissionsAuthManager(t, ctx)
+
+	// Get VM for node
+	vCenter, err := GetVCenter(ctx, node)
+	if err != nil {
+		t.Fatalf("error getting vCenter for node %s: %s", node.Name, err)
+	}
+	vm, err := testlib.GetVM(vCenter.VMClient, node)
+	if err != nil {
+		t.Fatalf("error getting vm for node %s: %s", node.Name, err)
+	}
+
+	// Act
+	err = check.CheckNode(ctx, node, vm)
+
+	// Assert: should NOT error due to beta labels being recognized for read-only detection
+	assert.NoError(t, err)
+}
+
+func TestCheckComputeClusterPermissions_MultipleFailureDomains_ReadOnly_WithBetaLabels(t *testing.T) {
+	// Stage
+	check := &CheckComputeClusterPermissions{}
+	if err := check.StartCheck(); err != nil {
+		t.Fatalf("StartCheck failed: %v", err)
+	}
+
+	// Node with BETA region/zone labels matching first failure domain
+	node := testlib.Node("DC0_H0_VM0", func(n *k8sv1.Node) {
+		if n.Labels == nil {
+			n.Labels = map[string]string{}
+		}
+		n.Labels[k8sv1.LabelFailureDomainBetaRegion] = "east"
+		n.Labels[k8sv1.LabelFailureDomainBetaZone] = "east-1a"
+	})
+
+	infra := testlib.InfrastructureWithMultipleFailureDomain(func(inf *ocpv1.Infrastructure) {
+		// Set a custom ResourcePool on first failure domain
+		inf.Spec.PlatformSpec.VSphere.FailureDomains[0].Topology.ResourcePool = "/DC0/host/DC0_C0/Resources/custom-pool"
+		// Set a custom ResourcePool on second failure domain
+		inf.Spec.PlatformSpec.VSphere.FailureDomains[1].Topology.ResourcePool = "/DC1/host/DC0_C1/Resources/another-pool"
+	})
+
+	kubeClient := &testlib.FakeKubeClient{
+		Infrastructure: infra,
+		Nodes:          []*k8sv1.Node{node},
+	}
+	ctx, cleanup, err := SetupSimulator(kubeClient, testlib.DefaultModel)
+	if err != nil {
+		t.Fatalf("setupSimulator failed: %s", err)
+	}
+	defer cleanup()
+
+	// Ensure legacy path does not interfere
+	if ctx.VMConfig.LegacyConfig != nil {
+		ctx.VMConfig.LegacyConfig.Workspace.ResourcePoolPath = ""
+	}
+	// Ensure cluster permissions would be missing if checked (to prove read_only skips)
+	setMissingClusterPermissionsAuthManager(t, ctx)
+
+	// Get VM for node
+	vCenter, err := GetVCenter(ctx, node)
+	if err != nil {
+		t.Fatalf("error getting vCenter for node %s: %s", node.Name, err)
+	}
+	vm, err := testlib.GetVM(vCenter.VMClient, node)
+	if err != nil {
+		t.Fatalf("error getting vm for node %s: %s", node.Name, err)
+	}
+
+	// Act
+	err = check.CheckNode(ctx, node, vm)
+
+	// Assert: beta labels should match failure domain, triggering read-only
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
OCPBUGS-79057

### Changes
- Changed node cluster permissions to not worry about failure domain region/zone when only one failure domain is defined due to installer potentially created fake / default failure domain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster permission detection for vSphere failure-domain setups: better region/zone label handling (including beta label variants), preserved multi-domain label matching, and a single-failure-domain shortcut that treats clusters using a custom resource pool as read-only when applicable.

* **Tests**
  * Added tests covering single- and multi–failure-domain scenarios, custom vs default resource pools, and both stable and beta region/zone labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->