### PR TITLE
OCPBUGS-87906: Fixed GetVCenter to handle removed FDs better

### DIFF
--- a/pkg/check/node_cluster_permissions_test.go
+++ b/pkg/check/node_cluster_permissions_test.go
@@ -358,8 +358,16 @@ func TestCheckComputeClusterPermissions_MultipleFailureDomains_RequiresLabelMatc
 		t.Fatalf("StartCheck failed: %v", err)
 	}
 
-	// Node without region/zone labels
-	node := testlib.Node("DC0_H0_VM0")
+	// Node with GA region/zone labels matching the first failure domain (region=east, zone=east-1a).
+	// Labels are required: GetVCenter returns an error when multiple FDs are configured and the
+	// node carries no labels, because it cannot safely determine which vCenter to use.
+	node := testlib.Node("DC0_H0_VM0", func(n *k8sv1.Node) {
+		if n.Labels == nil {
+			n.Labels = map[string]string{}
+		}
+		n.Labels[k8sv1.LabelTopologyRegion] = "east"
+		n.Labels[k8sv1.LabelTopologyZone] = "east-1a"
+	})
 
 	infra := testlib.InfrastructureWithMultipleFailureDomain(func(inf *ocpv1.Infrastructure) {
 		// Set custom ResourcePool on first failure domain

--- a/pkg/check/util.go
+++ b/pkg/check/util.go
@@ -319,11 +319,17 @@ func GetVCenter(checkContext *CheckContext, node *v1.Node) (*VCenter, error) {
 			zone = node.Labels[v1.LabelFailureDomainBetaZone]
 		}
 
-		// In older clusters, the region/zone will be blank on nodes and there will be no FD.
-		// However, region/zone being set is not enough to start looking for FailureDomain:
-		// in case of single (auto-generated) FailureDomain, topology-awareness is not enabled
-		// and we must fall back to the second "if" clause below (OCPBUGS-59319).
-		if len(region) > 0 && len(zone) > 0 && len(checkContext.PlatformSpec.FailureDomains) > 1 {
+		// If the node has region/zone labels, try to match them against a configured failure domain.
+		// We attempt this regardless of how many failure domains are defined: a cluster that previously
+		// had multiple FDs and was reduced to one still has correctly-labelled nodes that should be
+		// matched rather than silently falling back to "first FD".
+		//
+		// The guard of len(FailureDomains) > 1 was originally added (OCPBUGS-59319) to skip FD
+		// matching for clusters that have only the single auto-generated FD created by the OpenShift
+		// installer, where topology-awareness is not enabled and labels may be absent/meaningless.
+		// We preserve that intent by only skipping the match when labels are absent;
+		// if the labels are present we always attempt a match first and fall back only if no FD matches.
+		if len(region) > 0 && len(zone) > 0 {
 			klog.V(2).Infof("Checking for region %v zone %v", region, zone)
 			server := ""
 			// Get failure domain
@@ -334,33 +340,61 @@ func GetVCenter(checkContext *CheckContext, node *v1.Node) (*VCenter, error) {
 				}
 			}
 
-			// Maybe return error if server not found?
-			if server == "" {
-				return nil, fmt.Errorf("unable to determine vcenter for node %s", node.Name)
+			if server != "" {
+				vc := checkContext.VCenters[server]
+				if vc == nil {
+					return nil, fmt.Errorf("vCenter %v not found", server)
+				}
+				return vc, nil
 			}
 
-			return checkContext.VCenters[server], nil
-		} else {
-			// Node is not configured w/ FD labels.  Admin may not have updated control plane after migrating to
-			// multi vCenter config.
+			// Labels were present but no FD matched.  This can happen when the cluster has more
+			// than one vCenter and the node's labels don't correspond to any configured FD (e.g.
+			// the FD was removed).  Return an error so the caller knows the node is unresolvable
+			// rather than silently returning the wrong vCenter.
+			if len(checkContext.PlatformSpec.FailureDomains) > 1 {
+				return nil, fmt.Errorf("unable to determine vcenter for node %s: no failure domain matched region=%s zone=%s", node.Name, region, zone)
+			}
+
+			// Single FD cluster (or auto-generated FD): fall through to the first-FD fallback below
+			// so that the existing OCPBUGS-59319 behaviour is preserved.
+			klog.V(4).Infof("Node %s has region/zone labels but only one failure domain is configured; using it directly", node.Name)
+		}
+
+		// Node labels are absent, or we have exactly one FD and labels didn't match it (single-FD
+		// legacy cluster).  Fall back: return the first available vCenter/FD.
+		if len(region) == 0 || len(zone) == 0 {
+			// Node is not configured w/ FD labels.  Admin may not have updated control plane after
+			// migrating to multi-vCenter config.  If there are multiple failure domains we cannot
+			// safely guess which vCenter is correct, so return an error.  For a single-FD cluster
+			// the fallback to FDs[0] is unambiguous, so just warn.
+			if len(checkContext.PlatformSpec.FailureDomains) > 1 {
+				return nil, fmt.Errorf("failure domain labels missing from node %s when there are more than one failure domains configured", node.Name)
+			}
 			klog.Warningf("failure domain labels missing from node %s", node.Name)
-			if len(checkContext.PlatformSpec.FailureDomains) > 0 {
-				klog.V(2).Infof("Returning first FD defined in platform spec.")
-				for _, fd := range checkContext.PlatformSpec.FailureDomains {
-					return checkContext.VCenters[fd.Server], nil
-				}
-			} else {
-				klog.V(2).Infof("There are no failure domains in platform spec. Returning first vCenter from context.")
-				for index := range checkContext.VCenters {
-					return checkContext.VCenters[index], nil
-				}
+		}
+		if len(checkContext.PlatformSpec.FailureDomains) > 0 {
+			klog.V(2).Infof("Returning first FD defined in platform spec.")
+			fd := checkContext.PlatformSpec.FailureDomains[0]
+			vc := checkContext.VCenters[fd.Server]
+			if vc == nil {
+				return nil, fmt.Errorf("vCenter %v not found", fd.Server)
+			}
+			return vc, nil
+		} else {
+			klog.V(2).Infof("There are no failure domains in platform spec. Returning first vCenter from context.")
+			if len(checkContext.VCenters) > 1 {
+				return nil, fmt.Errorf("invalid number of configured vCenters detected: %d.  Expected only 1", len(checkContext.VCenters))
+			}
+			for index := range checkContext.VCenters {
+				return checkContext.VCenters[index], nil
 			}
 		}
 	} else {
 		// Platform spec is not set.  This is old behavior before FDs.  Return only FD.
 		klog.V(2).Infof("Infrastructure is not configured.  Returning first vCenter from context.")
 		if len(checkContext.VCenters) > 1 {
-			return nil, fmt.Errorf("invalid number of configured vCenters detected: %d.  Expected only 1.", len(checkContext.VCenters))
+			return nil, fmt.Errorf("invalid number of configured vCenters detected: %d.  Expected only 1", len(checkContext.VCenters))
 		}
 		for index := range checkContext.VCenters {
 			return checkContext.VCenters[index], nil

--- a/pkg/check/util_test.go
+++ b/pkg/check/util_test.go
@@ -453,6 +453,8 @@ func TestGetVCenter(t *testing.T) {
 			expectErr: "unable to determine vcenter for node DC0_H0_VM0",
 		},
 		{
+			// Node has no region/zone labels and there are 2 FDs pointing to different vCenters.
+			// We cannot safely determine which vCenter to use, so an error is expected.
 			name:        "platform spec with multiple vcenters no labels",
 			cloudConfig: "simple_config.yaml",
 			infra:       testlib.InfrastructureWithMultiVCenters(),
@@ -460,7 +462,93 @@ func TestGetVCenter(t *testing.T) {
 				node := testlib.DefaultNodes()[0]
 				return node
 			}(),
+			expectErr: "failure domain labels missing from node DC0_H0_VM0 when there are more than one failure domains configured",
+		},
+		// ── Scenarios exercising the fix for the "FD reduced from 2→1" regression ──────────────
+		{
+			// Node labels (GA) match the one configured FD (region=east, zone=east-1a).
+			// Expect: matched directly, no fallback, no warning.
+			name:        "single FD after reduction - GA labels match remaining FD (ini)",
+			cloudConfig: "simple_config.ini",
+			infra:       testlib.InfrastructureWithFailureDomain(),
+			node: func() *v1.Node {
+				node := testlib.DefaultNodes()[0]
+				node.Labels = make(map[string]string)
+				node.Labels[v1.LabelTopologyRegion] = "east"
+				node.Labels[v1.LabelTopologyZone] = "east-1a"
+				return node
+			}(),
+			server: "dc0",
+		},
+		{
+			// Same as above but with the legacy beta topology labels.
+			name:        "single FD after reduction - beta labels match remaining FD (ini)",
+			cloudConfig: "simple_config.ini",
+			infra:       testlib.InfrastructureWithFailureDomain(),
+			node: func() *v1.Node {
+				node := testlib.DefaultNodes()[0]
+				node.Labels = make(map[string]string)
+				node.Labels[v1.LabelFailureDomainBetaRegion] = "east"
+				node.Labels[v1.LabelFailureDomainBetaZone] = "east-1a"
+				return node
+			}(),
+			server: "dc0",
+		},
+		{
+			// YAML cloud-config flavour: single FD after reduction, GA labels match.
+			name:        "single FD after reduction - GA labels match remaining FD (yaml)",
+			cloudConfig: "config_single-vcenter.yaml",
+			infra: func() *ocpv1.Infrastructure {
+				// Start from the multi-vCenter infra (which has two FDs), then
+				// strip it down to one FD + one vCenter, simulating a customer
+				// who removed the second failure domain.
+				infra := testlib.InfrastructureWithMultiVCenters()
+				infra.Spec.PlatformSpec.VSphere.FailureDomains = infra.Spec.PlatformSpec.VSphere.FailureDomains[0:1]
+				infra.Spec.PlatformSpec.VSphere.VCenters = infra.Spec.PlatformSpec.VSphere.VCenters[0:1]
+				return infra
+			}(),
+			node: func() *v1.Node {
+				node := testlib.DefaultNodes()[0]
+				node.Labels = make(map[string]string)
+				// The first FD in InfrastructureWithMultiVCenters has region=east, zone=east-1a.
+				node.Labels[v1.LabelTopologyRegion] = "east"
+				node.Labels[v1.LabelTopologyZone] = "east-1a"
+				return node
+			}(),
 			server: "vcenter.test.openshift.com",
+		},
+		{
+			// Node labels are present but do NOT match the single remaining FD.
+			// With only 1 FD the new code falls through to the first-FD fallback
+			// (OCPBUGS-59319 behaviour preserved) rather than returning an error.
+			name:        "single FD after reduction - labels present but don't match (falls back to first FD)",
+			cloudConfig: "simple_config.ini",
+			infra:       testlib.InfrastructureWithFailureDomain(),
+			node: func() *v1.Node {
+				node := testlib.DefaultNodes()[0]
+				node.Labels = make(map[string]string)
+				node.Labels[v1.LabelTopologyRegion] = "unknown-region"
+				node.Labels[v1.LabelTopologyZone] = "unknown-zone"
+				return node
+			}(),
+			// No error: falls back to the single FD's vCenter (same as legacy behaviour).
+			server: "dc0",
+		},
+		{
+			// Multi-vCenter cluster: node labels are present but match no configured FD.
+			// With >1 FDs the new code must return a hard error instead of silently
+			// returning the wrong vCenter.
+			name:        "multiple FDs - labels present but match no FD returns error (ini)",
+			cloudConfig: "simple_config.ini",
+			infra:       testlib.InfrastructureWithMultipleFailureDomain(),
+			node: func() *v1.Node {
+				node := testlib.DefaultNodes()[0]
+				node.Labels = make(map[string]string)
+				node.Labels[v1.LabelTopologyRegion] = "removed-region"
+				node.Labels[v1.LabelTopologyZone] = "removed-zone"
+				return node
+			}(),
+			expectErr: "unable to determine vcenter for node DC0_H0_VM0",
 		},
 	}
 


### PR DESCRIPTION
OCPBUGS-87906

### Changes
- Enhanced GetVCenter logic to better handle finding vCenters for current node

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vCenter selection for nodes with region/zone topology labels by consistently applying failure-domain matching.
  * Refined fallback behavior for single failure-domain and reduced configurations, including deterministic selection when applicable.
  * Added clearer error handling when vCenter resolution can’t be determined, and warning behavior when topology labels are missing.
* **Tests**
  * Expanded automated coverage for multi-vCenter/multi–failure-domain edge cases and regression scenarios after reducing to fewer failure domains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->